### PR TITLE
fix: wrongs in compilation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,18 @@ cd OpenWrt-SDK-ar71xx-*
 
 # Clone 项目
 mkdir package/luci-app-openclash
-cd package/luci-app-openclash
+pushd package/luci-app-openclash
 git init
 git remote add -f origin https://github.com/vernesong/OpenClash.git
 git config core.sparsecheckout true
 echo "luci-app-openclash" >> .git/info/sparse-checkout
 git pull origin master
 git branch --set-upstream-to=origin/master master
+cp -r luci-app-openclash/* . # 编译要求 package 源码要在 package/luci-app-openclash 下
+popd
 
 # 编译 po2lmo (如果有po2lmo可跳过)
-pushd package/luci-app-openclash/luci-app-openclash/tools/po2lmo
+pushd package/luci-app-openclash/tools/po2lmo
 make && sudo make install
 popd
 
@@ -90,7 +92,7 @@ popd
 make menuconfig
 
 # 开始编译
-make package/luci-app-openclash/luci-app-openclash/compile V=99
+make package/luci-app-openclash/compile V=99
 
 # 您也可以直接拷贝 `luci-app-openclash` 文件夹至其他 `OpenWrt` 项目的 `Package` 目录下随固件编译
 ```


### PR DESCRIPTION
1.  cd to `package/luci-app-openclash` but didn't go back
2.  It seems that the package code must be laid in `package/luci-app-openclash`. The current layout will lead to:

```shell
/builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/scripts/ipkg-build -c -o 0 -g 0 /builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/build_dir/target-mipsel_1004kc+dsp_musl-1.1.16/luci-app-openclash/ipkg-all/luci-app-openclash /builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/bin/ramips/packages/base
make[2]: *** [Makefile:224: /builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/bin/ramips/packages/base/luci-app-openclash_0.39.7-beta_all.ipk] Error 1
make[2]: Leaving directory '/builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/package/luci-app-openclash'
make[1]: *** [package/Makefile:197: package/luci-app-openclash/compile] Error 2
make[1]: Leaving directory '/builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64'
make: *** [/builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/include/toplevel.mk:187: package/luci-app-openclash/compile] Error 2
```