### PR TITLE
fix: problems in compilation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 * ca-certificates
 * ipset
 * ip-full
+* subversion
 * iptables-mod-tproxy
 * kmod-tun(TUN模式)
 * luci-compat(Luci-19.07)

--- a/README.md
+++ b/README.md
@@ -73,13 +73,14 @@ cd OpenWrt-SDK-ar71xx-*
 
 # Clone 项目
 mkdir package/luci-app-openclash
-cd package/luci-app-openclash
+pushd package/luci-app-openclash
 git init
 git remote add -f origin https://github.com/vernesong/OpenClash.git
 git config core.sparsecheckout true
 echo "luci-app-openclash" >> .git/info/sparse-checkout
 git pull origin master
 git branch --set-upstream-to=origin/master master
+popd
 
 # 编译 po2lmo (如果有po2lmo可跳过)
 pushd package/luci-app-openclash/luci-app-openclash/tools/po2lmo


### PR DESCRIPTION
1.  cd to `package/luci-app-openclash` but didn't go back
2.  Missing `subversion` as a dependency, resulting in

```shell
/builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/scripts/ipkg-build -c -o 0 -g 0 /builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/build_dir/target-mipsel_1004kc+dsp_musl-1.1.16/luci-app-openclash/ipkg-all/luci-app-openclash /builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/bin/ramips/packages/base
make[2]: *** [Makefile:224: /builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/bin/ramips/packages/base/luci-app-openclash_0.39.7-beta_all.ipk] Error 1
make[2]: Leaving directory '/builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/package/luci-app-openclash'
make[1]: *** [package/Makefile:197: package/luci-app-openclash/compile] Error 2
make[1]: Leaving directory '/builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64'
make: *** [/builds/accessable-net/OpenClash/OpenWrt-SDK-ramips-mt7621_gcc-5.3.0_musl-1.1.16.Linux-x86_64/include/toplevel.mk:187: package/luci-app-openclash/compile] Error 2
```

BTW, I made a CI script to make the build process more trustworthy: https://gitlab.com/accessable-net/OpenClash/-/pipelines.