### PR TITLE
Update openclash_chnroute.sh

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/openclash_chnroute.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_chnroute.sh
@@ -41,7 +41,7 @@
    if [ "$?" -eq "0" ] && [ -s "/tmp/china_ip_route.txt" ]; then
       echo "大陆IP白名单下载成功，检查版本是否更新..." >$START_LOG
       #预处理
-      echo "create china_ip_route hash:net family inet hashsize 1024 maxelem 65536" >/tmp/china_ip_route.list
+      echo "create china_ip_route hash:net family inet hashsize 1024 maxelem 1000000" >/tmp/china_ip_route.list
       awk '!/^$/&&!/^#/{printf("add china_ip_route %s'" "'\n",$0)}' /tmp/china_ip_route.txt >>/tmp/china_ip_route.list
       cmp -s /tmp/china_ip_route.list "$chnr_path"
       if [ "$?" -ne "0" ]; then


### PR DESCRIPTION
大陆白名单选择Hackl0us规则时，只有65536行生效
Hackl0us规则本身有49万行
将maxelem值改为100万，即可全部生效