### PR TITLE
初步实现 TProxy IPv6 透明代理

### DIFF
--- a/luci-app-openclash/luasrc/model/cbi/openclash/settings.lua
+++ b/luci-app-openclash/luasrc/model/cbi/openclash/settings.lua
@@ -165,6 +165,13 @@ o.datatype = "port"
 o.rmempty = false
 o.description = translate("Please Make Sure Ports Available")
 
+o = s:taboption("settings", Value, "tproxy_port")
+o.title = translate("TProxy Port")
+o.default = 7895
+o.datatype = "port"
+o.rmempty = false
+o.description = translate("Please Make Sure Ports Available")
+
 o = s:taboption("settings", Value, "http_port")
 o.title = translate("HTTP(S) Port")
 o.default = 7890

--- a/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
+++ b/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
@@ -358,7 +358,7 @@ msgstr "运行后，请等待服务器上线"
 msgid "Redir Port"
 msgstr "流量转发端口"
 
-msgid "TPorxy Port"
+msgid "TProxy Port"
 msgstr "TProxy 端口"
 
 msgid "SOCKS5 Port"

--- a/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
+++ b/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
@@ -358,6 +358,9 @@ msgstr "运行后，请等待服务器上线"
 msgid "Redir Port"
 msgstr "流量转发端口"
 
+msgid "TPorxy Port"
+msgstr "TProxy 端口"
+
 msgid "SOCKS5 Port"
 msgstr "SOCKS5 代理端口"
 

--- a/luci-app-openclash/root/etc/config/openclash
+++ b/luci-app-openclash/root/etc/config/openclash
@@ -1,6 +1,7 @@
 
 config openclash 'config'
 	option proxy_port '7892'
+	option tproxy_port '7895'
 	option mixed_port '7893'
 	option socks_port '7891'
 	option http_port '7890'

--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1729,6 +1729,9 @@ get_config()
    cn_port=$(uci -q get openclash.config.cn_port)
    proxy_port=$(uci -q get openclash.config.proxy_port)
    tproxy_port=$(uci -q get openclash.config.tproxy_port)
+   if [ -z "$tproxy_port" ];then
+        tproxy_port=7895
+   else
    proxy_mode=$(uci -q get openclash.config.proxy_mode)
    ipv6_enable=$(uci -q get openclash.config.ipv6_enable)
    http_port=$(uci -q get openclash.config.http_port)

--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1662,21 +1662,6 @@ revert_firewall()
       iptables -t nat -D PREROUTING "$pre_line" >/dev/null 2>&1
    done >/dev/null 2>&1
 
-   pre_lines=$(ip6tables -nvL PREROUTING -t mangle |sed 1,2d |sed -n '/openclash/=' 2>/dev/null |sort -rn)
-   for pre_line in $pre_lines; do
-      ip6tables -t mangle -D PREROUTING "$pre_line" >/dev/null 2>&1
-   done >/dev/null 2>&1
-
-   out_lines=$(ip6tables -nvL OUTPUT -t mangle |sed 1,2d |sed -n '/openclash/=' 2>/dev/null |sort -rn)
-   for out_line in $out_lines; do
-      ip6tables -t mangle -D OUTPUT "$out_line" >/dev/null 2>&1
-   done >/dev/null 2>&1
-
-   #ipv6
-   #ip6tables -t mangle -F openclash >/dev/null 2>&1
-   #ip6tables -t mangle -D PREROUTING -p udp -j openclash >/dev/null 2>&1
-   #ip6tables -t mangle -X openclash >/dev/null 2>&1
-
    iptables -t nat -F openclash >/dev/null 2>&1
    iptables -t nat -X openclash >/dev/null 2>&1
    
@@ -1686,10 +1671,6 @@ revert_firewall()
    iptables -t nat -F openclash_post >/dev/null 2>&1
    iptables -t nat -X openclash_post >/dev/null 2>&1
    iptables -t nat -D POSTROUTING -j openclash_post >/dev/null 2>&1
-
-   ip6tables -t nat -F openclash >/dev/null 2>&1
-   ip6tables -t nat -D PREROUTING -p tcp -j openclash >/dev/null 2>&1
-   ip6tables -t nat -X openclash >/dev/null 2>&1
 
    #TUN
    ip route del default dev clash0 table "$PROXY_ROUTE_TABLE" >/dev/null 2>&1
@@ -1710,13 +1691,6 @@ revert_firewall()
    iptables -t mangle -F openclash_output >/dev/null 2>&1
    iptables -t mangle -X openclash_output >/dev/null 2>&1
 
-   ip6tables -t mangle -F openclash >/dev/null 2>&1
-   ip6tables -t mangle -X openclash >/dev/null 2>&1
-   ip6tables -t mangle -F openclash_output >/dev/null 2>&1
-   ip6tables -t mangle -X openclash_output >/dev/null 2>&1
-
-   #ip6tables -t mangle -D PREROUTING -j MARK --set-mark "$PROXY_FWMARK" >/dev/null 2>&1
-
    ipset destroy localnetwork >/dev/null 2>&1
    ipset destroy china_ip_route >/dev/null 2>&1
    ipset destroy lan_ac_white_ips >/dev/null 2>&1
@@ -1725,6 +1699,24 @@ revert_firewall()
    ipset destroy lan_ac_black_macs >/dev/null 2>&1
    ipset destroy wan_ac_black_ips >/dev/null 2>&1
    ipset destroy common_ports >/dev/null 2>&1
+
+   #Revert IPv6 rules
+
+   pre_lines=$(ip6tables -nvL PREROUTING -t mangle |sed 1,2d |sed -n '/openclash/=' 2>/dev/null |sort -rn)
+   for pre_line in $pre_lines; do
+      ip6tables -t mangle -D PREROUTING "$pre_line" >/dev/null 2>&1
+   done >/dev/null 2>&1
+
+   out_lines=$(ip6tables -nvL OUTPUT -t mangle |sed 1,2d |sed -n '/openclash/=' 2>/dev/null |sort -rn)
+   for out_line in $out_lines; do
+      ip6tables -t mangle -D OUTPUT "$out_line" >/dev/null 2>&1
+   done >/dev/null 2>&1
+
+   ip6tables -t mangle -F openclash >/dev/null 2>&1
+   ip6tables -t mangle -X openclash >/dev/null 2>&1
+   ip6tables -t mangle -F openclash_output >/dev/null 2>&1
+   ip6tables -t mangle -X openclash_output >/dev/null 2>&1
+
    ipset destroy localnetwork6 >/dev/null 2>&1
 }
 

--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1367,6 +1367,26 @@ fi
       done
    fi
 
+   ipset create localnetwork6 hash:net family inet6
+   ipset add localnetwork6 ::/128
+   ipset add localnetwork6 ::1/128
+   ipset add localnetwork6 ::ffff:0:0/96
+   ipset add localnetwork6 ::ffff:0:0:0/96
+   ipset add localnetwork6 64:ff9b::/96
+   ipset add localnetwork6 100::/64
+   ipset add localnetwork6 2001::/32
+   ipset add localnetwork6 2001:20::/28
+   ipset add localnetwork6 2001:db8::/32
+   ipset add localnetwork6 2002::/16
+   ipset add localnetwork6 fc00::/7
+   ipset add localnetwork6 fe80::/10
+   ipset add localnetwork6 ff00::/8
+
+   if [ -n "$wan_ip6" ]; then
+      for wan_ip6s in $wan_ip6; do
+         ipset add localnetwork6 "$wan_ip6s"
+      done
+   fi
 #common ports
 if [ "$common_ports" = "1" ]; then
    common_port="21 22 23 53 80 123 143 194 443 465 587 853 993 995 998 2052 2053 2082 2083 2086 2095 2096 5222 5228 5229 5230 8080 8443 8880 8888 8889"
@@ -1457,31 +1477,37 @@ if [ -z "$en_mode_tun" ] || [ "$en_mode_tun" -eq 3 ]; then
          
       fi
    fi
-   #if [ "$ipv6_enable" -eq 1 ]; then
-   #   #tcp
-   #   ip6tables -t nat -N openclash
-   #   if [ -n "$lan_ip6" ]; then
-   #      for lan_ip6s in $lan_ip6; do
-   #         ip6tables -t nat -A openclash -d "$lan_ip6s" -j RETURN 2>/dev/null
-   #      done
-   #   fi
-   #   ip6tables -t nat -A openclash -p tcp -j REDIRECT --to-ports "$proxy_port"
-   #   ip6tables -t nat -A PREROUTING -p tcp -j openclash
 
-      #udp
-      #if [ "$enable_udp_proxy" -eq 1 ]; then
-      #   ip6tables -t mangle -N openclash
-      #   if [ -n "$lan_ip6" ]; then
-      #      for lan_ip6s in $lan_ip6; do
-      #         if [ "$enable_udp_proxy" -eq 1 ]; then
-      #            ip6tables -t mangle -A openclash -d "$lan_ip6s" -j RETURN 2>/dev/null
-      #         fi
-      #      done
-      #   fi
-      #   ip6tables -t mangle -A openclash -p udp -j TPROXY --on-port "$proxy_port" --tproxy-mark "$PROXY_FWMARK"
-      #   ip6tables -t mangle -A PREROUTING -p udp -j openclash
-      #fi
-   #fi 2>/dev/null
+   iptables -t nat -I OUTPUT -j openclash_output
+
+   if [ "$ipv6_enable" -eq 1 ]; then
+
+      ip6tables -t mangle -N openclash
+      ip6tables -t mangle -F openclash
+      ip6tables -t mangle -A openclash -m set --match-set localnetwork6 dst -j RETURN
+      ip6tables -t mangle -A PREROUTING -j openclash
+
+      ip6tables -t mangle -N openclash_output
+      ip6tables -t mangle -F openclash_output
+      ip6tables -t mangle -A openclash_output -m set --match-set localnetwork6 dst -j RETURN
+      ip6tables -t mangle -A OUTPUT -j openclash_output
+
+      ip -6 rule add fwmark "$PROXY_FWMARK" table "$PROXY_ROUTE_TABLE"
+      ip -6 route add local ::/0 dev lo table "$PROXY_ROUTE_TABLE"
+
+      ip6tables -t mangle -A openclash_output -p tcp -j MARK --set-xmark "$PROXY_FWMARK"
+      ip6tables -t mangle -A openclash_output -p udp -j MARK --set-xmark "$PROXY_FWMARK"
+
+
+      ip6tables -t mangle -A openclash -p tcp -m comment --comment "\'默认\'" -j TPROXY --on-port "$tproxy_port" --tproxy-mark "$PROXY_FWMARK"
+
+      ip6tables -t mangle -A openclash -p udp -m comment --comment "\'默认\'" -j TPROXY --on-port "$tproxy_port" --tproxy-mark "$PROXY_FWMARK"
+
+      # 防止出现死循环
+      ip6tables -t mangle -I openclash -p udp --dport "$tproxy_port" -j RETURN
+      ip6tables -t mangle -I openclash -p tcp --dport "$tproxy_port" -j RETURN
+
+   fi 2>/dev/null
 fi
 if [ -n "$en_mode_tun" ]; then
    #TUN模式
@@ -1599,6 +1625,9 @@ revert_firewall()
    ip rule del fwmark "$PROXY_FWMARK" table "$PROXY_ROUTE_TABLE" >/dev/null 2>&1
    ip route del local 0.0.0.0/0 dev lo table "$PROXY_ROUTE_TABLE" >/dev/null 2>&1
 
+   ip -6 rule del fwmark "$PROXY_FWMARK" table "$PROXY_ROUTE_TABLE"
+   ip -6 route del local ::/0 dev lo table "$PROXY_ROUTE_TABLE"
+
    iptables -t nat -D PREROUTING -p tcp --dport 53 -j ACCEPT >/dev/null 2>&1
    
    iptables -D FORWARD -p udp --dport 443 -j REJECT >/dev/null 2>&1
@@ -1675,6 +1704,11 @@ revert_firewall()
    iptables -t mangle -F openclash_output >/dev/null 2>&1
    iptables -t mangle -X openclash_output >/dev/null 2>&1
 
+   ip6tables -t mangle -F openclash >/dev/null 2>&1
+   ip6tables -t mangle -X openclash >/dev/null 2>&1
+   ip6tables -t mangle -F openclash_output >/dev/null 2>&1
+   ip6tables -t mangle -X openclash_output >/dev/null 2>&1
+
    #ip6tables -t mangle -D PREROUTING -j MARK --set-mark "$PROXY_FWMARK" >/dev/null 2>&1
 
    ipset destroy localnetwork >/dev/null 2>&1
@@ -1685,6 +1719,7 @@ revert_firewall()
    ipset destroy lan_ac_black_macs >/dev/null 2>&1
    ipset destroy wan_ac_black_ips >/dev/null 2>&1
    ipset destroy common_ports >/dev/null 2>&1
+   ipset destroy localnetwork6 >/dev/null 2>&1
 }
 
 get_config()
@@ -1695,6 +1730,7 @@ get_config()
    da_password=$(uci -q get openclash.config.dashboard_password)
    cn_port=$(uci -q get openclash.config.cn_port)
    proxy_port=$(uci -q get openclash.config.proxy_port)
+   tproxy_port=$(uci -q get openclash.config.tproxy_port)
    proxy_mode=$(uci -q get openclash.config.proxy_mode)
    ipv6_enable=$(uci -q get openclash.config.ipv6_enable)
    http_port=$(uci -q get openclash.config.http_port)
@@ -1704,6 +1740,7 @@ get_config()
    lan_ip_cidrs=$(ip route | grep "/" | awk '{print $1}' | grep -vE "^198.18" 2>/dev/null)
    wan_ip4s=$(ifconfig | grep 'inet addr' | awk '{print $2}' | cut -d: -f2 | grep -vE "(^198.18|^192.168|^127.0)" 2>/dev/null)
    lan_ip6=$(ifconfig | grep 'inet6 addr' | awk '{print $3}' 2>/dev/null)
+   wan_ip6=$(ifconfig | grep 'inet6 addr' | awk '{print $3}' 2>/dev/null)
    disable_masq_cache=$(uci -q get openclash.config.disable_masq_cache)
    log_level=$(uci -q get openclash.config.log_level)
    intranet_allowed=$(uci -q get openclash.config.intranet_allowed)
@@ -1749,7 +1786,7 @@ start()
    config_foreach yml_auth_get "authentication"
    yml_auth_custom "$CONFIG_FILE"
    yml_dns_custom "$enable_custom_dns" "$CONFIG_FILE"
-   /usr/share/openclash/yml_change.sh 2>/dev/null "$LOGTIME" "$en_mode" "$enable_custom_dns" "$da_password" "$cn_port" "$proxy_port" "$CONFIG_FILE" "$ipv6_enable" "$http_port" "$socks_port" "$lan_ip" "$log_level" "$proxy_mode" "$intranet_allowed" "$en_mode_tun" "$stack_type" "$dns_port" "$core_type" "$mixed_port"
+   /usr/share/openclash/yml_change.sh 2>/dev/null "$LOGTIME" "$en_mode" "$enable_custom_dns" "$da_password" "$cn_port" "$proxy_port" "$CONFIG_FILE" "$ipv6_enable" "$http_port" "$socks_port" "$lan_ip" "$log_level" "$proxy_mode" "$intranet_allowed" "$en_mode_tun" "$stack_type" "$dns_port" "$core_type" "$mixed_port" "$tproxy_port"
    /usr/share/openclash/yml_rules_change.sh 2>/dev/null "$LOGTIME" "$rule_source" "$enable_custom_clash_rules" "$CONFIG_FILE" "$enable_rule_proxy" "$CONFIG_NAME"
    yml_custom_rule_provider
    yml_game_custom

--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1495,18 +1495,14 @@ if [ -z "$en_mode_tun" ] || [ "$en_mode_tun" -eq 3 ]; then
       ip -6 rule add fwmark "$PROXY_FWMARK" table "$PROXY_ROUTE_TABLE"
       ip -6 route add local ::/0 dev lo table "$PROXY_ROUTE_TABLE"
 
-      ip6tables -t mangle -A openclash_output -p tcp -j MARK --set-xmark "$PROXY_FWMARK"
-      ip6tables -t mangle -A openclash_output -p udp -j MARK --set-xmark "$PROXY_FWMARK"
+      # 防止出现死循环
+      ip6tables -t mangle -A openclash_output -p tcp -m owner ! --uid-owner 65534 -j MARK --set-xmark "$PROXY_FWMARK"
+      ip6tables -t mangle -A openclash_output -p udp -m owner ! --uid-owner 65534 -j MARK --set-xmark "$PROXY_FWMARK"
 
 
       ip6tables -t mangle -A openclash -p tcp -m comment --comment "\'默认\'" -j TPROXY --on-port "$tproxy_port" --tproxy-mark "$PROXY_FWMARK"
 
       ip6tables -t mangle -A openclash -p udp -m comment --comment "\'默认\'" -j TPROXY --on-port "$tproxy_port" --tproxy-mark "$PROXY_FWMARK"
-
-      # 防止出现死循环
-      ip6tables -t mangle -I openclash -p udp --dport "$tproxy_port" -j RETURN
-      ip6tables -t mangle -I openclash -p tcp --dport "$tproxy_port" -j RETURN
-
    fi 2>/dev/null
 fi
 if [ -n "$en_mode_tun" ]; then

--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1662,6 +1662,16 @@ revert_firewall()
       iptables -t nat -D PREROUTING "$pre_line" >/dev/null 2>&1
    done >/dev/null 2>&1
 
+   pre_lines=$(ip6tables -nvL PREROUTING -t mangle |sed 1,2d |sed -n '/openclash/=' 2>/dev/null |sort -rn)
+   for pre_line in $pre_lines; do
+      ip6tables -t mangle -D PREROUTING "$pre_line" >/dev/null 2>&1
+   done >/dev/null 2>&1
+
+   out_lines=$(ip6tables -nvL OUTPUT -t mangle |sed 1,2d |sed -n '/openclash/=' 2>/dev/null |sort -rn)
+   for out_line in $out_lines; do
+      ip6tables -t mangle -D OUTPUT "$out_line" >/dev/null 2>&1
+   done >/dev/null 2>&1
+
    #ipv6
    #ip6tables -t mangle -F openclash >/dev/null 2>&1
    #ip6tables -t mangle -D PREROUTING -p udp -j openclash >/dev/null 2>&1

--- a/luci-app-openclash/root/usr/share/openclash/yml_change.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_change.sh
@@ -66,6 +66,7 @@ rescue Exception => e
 end
 begin
    Value['redir-port']=$6;
+   Value['tproxy-port']=$20;
    Value['port']=$9;
    Value['socks-port']=${10};
    Value['mixed-port']=${19};


### PR DESCRIPTION
### 说明

1. IPv6 TCP+UDP 都走 TProxy
2. IPv6 所有流量都经过 Clash

### 测试 ipk 
[luci-app-openclash_0.43.01-beta_all.ipk.zip](https://github.com/vernesong/OpenClash/files/6223564/luci-app-openclash_0.43.01-beta_all.ipk.zip)


### TCP 测试

```
$ curl -6 https://www.google.com/ -v > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 2404:6800:4005:80b::2004:443...
* Connected to www.google.com (2404:6800:4005:80b::2004) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* TLS 1.2 connection using TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
* Server certificate: www.google.com
* Server certificate: GTS CA 1O1
* Server certificate: GlobalSign
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fe29880f600)
> GET / HTTP/2
> Host: www.google.com
> user-agent: curl/7.71.1
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0< HTTP/2 302
< location: https://www.google.com.hk/url?sa=p&hl=zh-CN&pref=hkredirect&pval=yes&q=https://www.google.com.hk/&ust=1617001044461397&usg=AOvVaw3mSsTaABMACaOZJhgSpaDZ
< cache-control: private
< content-type: text/html; charset=UTF-8
< p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
< date: Mon, 29 Mar 2021 06:56:54 GMT
< server: gws
< content-length: 372
< x-xss-protection: 0
< x-frame-options: SAMEORIGIN
< set-cookie: 1P_JAR=2021-03-29-06; expires=Wed, 28-Apr-2021 06:56:54 GMT; path=/; domain=.google.com; Secure
< set-cookie: NID=212=BIzRA5SsqWjgyHLSNIoSX868ww-P7S8i0i0mfupYOHsJV2TWuGGsoyZOL7Qy01Z2m9nMiZjUMXgO2Ol4t9oKvyqGF2wlTrZCZOGJhJFxbUDA_WWt0KBzaTpeIc3r3CQOEynPp4OJdeeQEibZpH8rFJNft33_0mcqKqkGPLbibFY; expires=Tue, 28-Sep-2021 06:56:54 GMT; path=/; domain=.google.com; HttpOnly
< alt-svc: h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
<
{ [372 bytes data]
100   372  100   372    0     0    732      0 --:--:-- --:--:-- --:--:--   730
* Connection #0 to host www.google.com left intact
```

### UDP 测试

```

time="2021-03-30T18:55:28Z" level=info msg="[UDP] [240e:xxxx::9e2]:48762 --> imciel.com match Match() using 🚀 Proxy[x1.0 美西 - 直连2]"



➜  ~ docker run -it --network bridge  --rm cielpy/curl-http3:7.75.0-0.7.0 curl -ILv --http3 --max-time 8 https://imciel.com/ -6
*   Trying 2606:4700:3031::6815:4b73:443...
* Connect socket 5 over QUIC to 2606:4700:3031::6815:4b73:443
* Sent QUIC client Initial, ALPN: h3-29,h3-28,h3-27
* Connected to imciel.com () port 443 (#0)
* h3 [:method: HEAD]
* h3 [:path: /]
* h3 [:scheme: https]
* h3 [:authority: imciel.com]
* h3 [user-agent: curl/7.75.0-DEV]
* h3 [accept: */*]
* Using HTTP/3 Stream ID: 0 (easy handle 0x559305d1d180)
> HEAD / HTTP/3
> Host: imciel.com
> user-agent: curl/7.75.0-DEV
> accept: */*
>
< HTTP/3 200
HTTP/3 200
< date: Tue, 30 Mar 2021 18:55:28 GMT
date: Tue, 30 Mar 2021 18:55:28 GMT
< content-type: text/html; charset=utf-8
content-type: text/html; charset=utf-8
< set-cookie: __cfduid=daaf041b414af76b452bde17dc305054f1617130528; expires=Thu, 29-Apr-21 18:55:28 GMT; path=/; domain=.imciel.com; HttpOnly; SameSite=Lax
set-cookie: __cfduid=daaf041b414af76b452bde17dc305054f1617130528; expires=Thu, 29-Apr-21 18:55:28 GMT; path=/; domain=.imciel.com; HttpOnly; SameSite=Lax
< cache-control: public, max-age=0, must-revalidate
cache-control: public, max-age=0, must-revalidate
< cf-cache-status: DYNAMIC
cf-cache-status: DYNAMIC
< cf-request-id: 092616b74c0000ed3f2696b000000001
cf-request-id: 092616b74c0000ed3f2696b000000001
< expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
< report-to: {"max_age":604800,"group":"cf-nel","endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=i1Z5TLmAGpn4MG6JX7D630Zp9X8Wr6Z%2BOBTndBS3uPlslfr6sHn8arJCvOw6hhpkIZrSsl1c653KrzHkTj4RH96JAe%2FUkl087NzY"}]}
report-to: {"max_age":604800,"group":"cf-nel","endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=i1Z5TLmAGpn4MG6JX7D630Zp9X8Wr6Z%2BOBTndBS3uPlslfr6sHn8arJCvOw6hhpkIZrSsl1c653KrzHkTj4RH96JAe%2FUkl087NzY"}]}
< nel: {"report_to":"cf-nel","max_age":604800}
nel: {"report_to":"cf-nel","max_age":604800}
< vary: Accept-Encoding
vary: Accept-Encoding
< x-content-type-options: nosniff
x-content-type-options: nosniff
< server: cloudflare
server: cloudflare
< cf-ray: 63838d6bac34ed3f-SJC
cf-ray: 63838d6bac34ed3f-SJC
< alt-svc: h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400
alt-svc: h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400
* Connection #0 to host imciel.com left intact
```

### 相关 issue

#1311 #1072 #1078 

### 剩余工作

- [x] 确认 UDP 工作正常 （缺测试用例）
- [ ] 适配绕过中国大陆IP模式
- [ ] 适配仅允许常用端口流量
- [ ] 其他？