### PR TITLE
修复当API获取不到IP时Dashboard打不开的情况

### DIFF
--- a/luci-app-openclash/luasrc/view/openclash/status.htm
+++ b/luci-app-openclash/luasrc/view/openclash/status.htm
@@ -407,7 +407,7 @@
         XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "status")%>', status.cn_port, function(x, status) {
         btn.disabled = true;
         btn.value    = '<%:Open Panel%>';
-        url2='<%="http://'+window.location.hostname+':'+status.cn_port+'/ui/?host='+ status.daip + '&port=' + (window.location.port || status.cn_port) + '&secret=' + status.dase +'"%>';
+        url2='<%="http://'+window.location.hostname+':'+status.cn_port+'/ui/?host='+ (status.daip|window.location.hostname) + '&port=' + (window.location.port || status.cn_port) + '&secret=' + status.dase +'"%>';
         winOpen(url2);
         return false;
         });


### PR DESCRIPTION
修复当API获取不到IP时Dashboard打不开的情况

(如果本地网络网卡名不叫lan时获取不到ip)

(dashboard URI中如果存在hostname字段但没有值会报错)