### PR TITLE
添加依赖 libcap-bin，以便安装OpenClash时自动安装libcap-bin

### DIFF
--- a/luci-app-openclash/Makefile
+++ b/luci-app-openclash/Makefile
@@ -18,7 +18,7 @@ define Package/$(PKG_NAME)
 	SUBMENU:=3. Applications
 	TITLE:=LuCI support for clash
 	PKGARCH:=all
-	DEPENDS:=+iptables +dnsmasq-full +coreutils +coreutils-nohup +bash +curl +ca-certificates +ipset +ip-full +iptables-mod-tproxy +iptables-mod-extra +libcap +ruby +ruby-yaml
+	DEPENDS:=+iptables +dnsmasq-full +coreutils +coreutils-nohup +bash +curl +ca-certificates +ipset +ip-full +iptables-mod-tproxy +iptables-mod-extra +libcap +libcap-bin +ruby +ruby-yaml
 	MAINTAINER:=vernesong
 endef
 


### PR DESCRIPTION
解决 https://github.com/vernesong/OpenClash/issues/839
添加依赖 libcap-bin，以便安装OpenClash时自动安装libcap-bin