### PR TITLE
添加libcap-bin依赖声明

### DIFF
--- a/luci-app-openclash/Makefile
+++ b/luci-app-openclash/Makefile
@@ -18,7 +18,7 @@ define Package/$(PKG_NAME)
 	SUBMENU:=3. Applications
 	TITLE:=LuCI support for clash
 	PKGARCH:=all
-	DEPENDS:=+iptables +dnsmasq-full +coreutils +coreutils-nohup +bash +curl +ca-certificates +ipset +ip-full +iptables-mod-tproxy +iptables-mod-extra +libcap +ruby +ruby-yaml
+	DEPENDS:=+iptables +dnsmasq-full +coreutils +coreutils-nohup +bash +curl +ca-certificates +ipset +ip-full +iptables-mod-tproxy +iptables-mod-extra +libcap +libcap-bin +ruby +ruby-yaml
 	MAINTAINER:=vernesong
 endef
 


### PR DESCRIPTION
今天用官方分支的OpenWrt 21.02 opkg安装完无法启动，发现这个依赖没有自动安装上