### PR TITLE
修正规则翻译表

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/res/game_rules.list
+++ b/luci-app-openclash/root/usr/share/openclash/res/game_rules.list
@@ -131,8 +131,8 @@ Steam-社区(Beta),Steam.rules
 全境封锁2,Tom-clancy's-The-Division.rules,Tom-clancys-The-Division.rules
 未转变者Unturned,Unturned.rules
 无畏契约,Valorant.rules
-战争前线,War-thunder-steam.rules
-战争雷霆-steam,Warface.rules
+战争雷霆,War-thunder-steam.rules
+战争前线-steam,Warface.rules
 看门狗,Watch-Dogs.rules
 看门狗2,Watch-Dogs2.rules
 求生意志OL,Will-To-Live-Online.rules


### PR DESCRIPTION
战争雷霆与战争前线规则名字修正翻译