### PR TITLE
fix: 'custom rule provider use tun core' don't work

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1096,8 +1096,7 @@ do_run_file()
    
    config_load "openclash"
    config_set_custom_rule_provider=0
-   checkList="rule_provider_config rule_providers game_config"
-   for i in $checkList; do
+   for i in "rule_provider_config" "rule_providers game_config"; do
       config_foreach custom_rule_provider "$i"
       if [ "$config_set_custom_rule_provider" -eq 1 ]; then
       	break


### PR DESCRIPTION
fix commit:8acd80a7d648f49833e02217921f1a7c51405a5e don't work.
if ehco $i in the for loop function, i got: 'rule_provider_config rule_providers game_config', but not each one.