### PR TITLE
fix: 修复数字密码支持

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/openclash.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash.sh
@@ -157,7 +157,7 @@ config_cus_up()
 config_su_check()
 {
    LOG_OUT "Config File Download Successful, Check If There is Any Update..."
-   sed -i 's/!<str> //g' "$CFG_FILE" >/dev/null 2>&1
+   sed -i 's/!<str> /!str /g' "$CFG_FILE" >/dev/null 2>&1
    if [ -f "$CONFIG_FILE" ]; then
       cmp -s "$BACKPACK_FILE" "$CFG_FILE"
       if [ "$?" -ne 0 ]; then

--- a/luci-app-openclash/root/usr/share/openclash/openclash.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash.sh
@@ -157,7 +157,7 @@ config_cus_up()
 config_su_check()
 {
    LOG_OUT "Config File Download Successful, Check If There is Any Update..."
-   sed -i 's/!<str> /!str /g' "$CFG_FILE" >/dev/null 2>&1
+   sed -i 's/!<str> /!!str /g' "$CFG_FILE" >/dev/null 2>&1
    if [ -f "$CONFIG_FILE" ]; then
       cmp -s "$BACKPACK_FILE" "$CFG_FILE"
       if [ "$?" -ne 0 ]; then


### PR DESCRIPTION
测试了下，clash 最新版本已经不支持 `!<str>` 和纯数字的格式

```
proxies:
  # 纯数字，不支持
  - {name: name, server: 1.1.1.1, port: 123, type: ss, cipher: aes-256-cfb, password: 4415934295}
  # 引号字符串，支持
  - {name: name, server: 1.1.1.1, port: 123, type: ss, cipher: aes-256-cfb, password: "4415934295"}
  # subconverter 输出，不支持
  - {name: name, server: 1.1.1.1, port: 123, type: ss, cipher: aes-256-cfb, password: !<str> 4415934295}
  # yaml 转换类型，支持
  - {name: name, server: 1.1.1.1, port: 123, type: ss, cipher: aes-256-cfb, password: !str 4415934295}
  # yaml 转换类型，支持
  - {name: name, server: 1.1.1.1, port: 123, type: ss, cipher: aes-256-cfb, password: !!str 4415934295}
```