### PR TITLE
fix: firewall rule flush while stop

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1044,7 +1044,7 @@ fi
 
 mkdir -p /var/etc
 cat > "/var/etc/openclash.include" <<-EOF
-/etc/init.d/openclash reload >/dev/null 2>&1
+/etc/init.d/openclash reload_firewall >/dev/null 2>&1
 EOF
 
 if [ "$china_ip_route" = "1" ] || [ "$disable_udp_quic" = "1" ]; then
@@ -1720,7 +1720,7 @@ restart()
    del_lock
 }
 
-reload()
+reload_firewall()
 {
    if pidof clash >/dev/null; then
       set_lock


### PR DESCRIPTION
Test on: OpenWrt Master SNAPSHOT
Help wanted: Test on OpenWrt 21.02 branch

修改内容:
1. 修复页面上点击'关闭OPENCLASH'时, 防火墙规则无法正常清空的问题;