### PR TITLE
fixed subscription-userinfo missing expire

### DIFF
--- a/luci-app-openclash/luasrc/controller/openclash.lua
+++ b/luci-app-openclash/luasrc/controller/openclash.lua
@@ -596,14 +596,16 @@ function sub_info_get()
 								download = string.sub(string.match(info, "download=%d+"), 10, -1) or nil
 								total = tonumber(string.format("%.1f",string.sub(string.match(info, "total=%d+"), 7, -1))) or nil
 								used = tonumber(string.format("%.1f",(upload + download))) or nil
-								day_expire = tonumber(string.sub(string.match(info, "expire=%d+"), 8, -1)) or nil
-								expire = os.date("%Y-%m-%d", day_expire) or "null"
-								if day_expire and os.time() <= day_expire then
-									day_left = math.ceil((day_expire - os.time()) / (3600*24))
-								elseif day_expire == nil then
-									day_left = "null"
-								else
-									day_left = 0
+								if string.find(info, "expire") then
+									day_expire = tonumber(string.sub(string.match(info, "expire=%d+"), 8, -1)) or nil
+									expire = os.date("%Y-%m-%d", day_expire) or "null"
+									if day_expire and os.time() <= day_expire then
+										day_left = math.ceil((day_expire - os.time()) / (3600*24))
+									elseif day_expire == nil then
+										day_left = "null"
+									else
+										day_left = 0
+									end
 								end
 								if used and total and used <= total then
 									percent = string.format("%.1f",(used/total)*100) or nil

--- a/luci-app-openclash/luasrc/controller/openclash.lua
+++ b/luci-app-openclash/luasrc/controller/openclash.lua
@@ -596,17 +596,18 @@ function sub_info_get()
 								download = string.sub(string.match(info, "download=%d+"), 10, -1) or nil
 								total = tonumber(string.format("%.1f",string.sub(string.match(info, "total=%d+"), 7, -1))) or nil
 								used = tonumber(string.format("%.1f",(upload + download))) or nil
-								if string.find(info, "expire") then
+								if string.match(info, "expire=%d+") then
 									day_expire = tonumber(string.sub(string.match(info, "expire=%d+"), 8, -1)) or nil
-									expire = os.date("%Y-%m-%d", day_expire) or "null"
-									if day_expire and os.time() <= day_expire then
-										day_left = math.ceil((day_expire - os.time()) / (3600*24))
-									elseif day_expire == nil then
-										day_left = "null"
-									else
-										day_left = 0
-									end
 								end
+								expire = os.date("%Y-%m-%d", day_expire) or "null"
+								if day_expire and os.time() <= day_expire then
+									day_left = math.ceil((day_expire - os.time()) / (3600*24))
+								elseif day_expire == nil then
+									day_left = "null"
+								else
+									day_left = 0
+								end
+								
 								if used and total and used <= total then
 									percent = string.format("%.1f",(used/total)*100) or nil
 								elseif used == nil or total == nil or total == 0 then


### PR DESCRIPTION
/usr/lib/lua/luci/controller/openclash.lua:599: bad argument #1 to 'sub' (string expected, got nil)
subscription-userinfo missing expire
subscription-userinfo: upload= ; download=; total= ; 
只有上面三个
缺expire= ;
#2465 
自问自答
patch-1效果
<img width="226" alt="Screenshot 2022-06-10 212546" src="https://user-images.githubusercontent.com/27732431/173077824-2bb7e20b-8b5e-419e-89b6-adf54dc49169.png">
