### PR TITLE
Update openclash.lua

### DIFF
--- a/luci-app-openclash/luasrc/controller/openclash.lua
+++ b/luci-app-openclash/luasrc/controller/openclash.lua
@@ -582,9 +582,9 @@ function sub_info_get()
 					_, len = string.gsub(s.address, '[^\n]+', "")
 					if len and len > 1 then return end
 					sub_url = s.address
-					info = luci.sys.exec(string.format("curl -sLI -m 10 -w 'http_code='%%{http_code} -H 'User-Agent: Clash' '%s'", sub_url))
+					info = luci.sys.exec(string.format("curl -sLI -X GET -m 10 -w 'http_code='%%{http_code} -H 'User-Agent: Clash' '%s'", sub_url))
 					if not info or tonumber(string.sub(string.match(info, "http_code=%d+"), 11, -1)) ~= 200 then
-						info = luci.sys.exec(string.format("curl -sLI -m 10 -w 'http_code='%%{http_code} -H 'User-Agent: Quantumultx' '%s'", sub_url))
+						info = luci.sys.exec(string.format("curl -sLI -X GET -m 10 -w 'http_code='%%{http_code} -H 'User-Agent: Quantumultx' '%s'", sub_url))
 					end
 					if info then
 						http_code=string.sub(string.match(info, "http_code=%d+"), 11, -1)


### PR DESCRIPTION
correct sub_info_get() fails to get http header when sub_url is generated by subconverter 0.72 and above.