### PR TITLE
Update idea.css: optimizing font display in log

### DIFF
--- a/luci-app-openclash/root/www/luci-static/resources/openclash/theme/idea.css
+++ b/luci-app-openclash/root/www/luci-static/resources/openclash/theme/idea.css
@@ -25,7 +25,7 @@
 
 .cm-s-idea span.cm-builtin { color: #30a; }
 .cm-s-idea span.cm-bracket { color: #cc7; }
-.cm-s-idea  { font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;}
+.cm-s-idea  { font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;}
 
 
 .cm-s-idea .CodeMirror-matchingbracket { outline:1px solid grey; color:black !important; }


### PR DESCRIPTION
运行日志显示界面字体映射有点小问题，具体是 idea.css 中这一行：

`.cm-s-idea  { font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;}`

在一堆等宽字体后突然出现了 serif，在 Mac 上会映射为宋体。这是不应该的，因为开头排到的几个代码字体都是无衬线体，和宋体不搭配。将 serif 改为 sans-serif，问题解决。Windows 上因为排在前位的 monospace 本就映射为宋体，所以没有变化。若要搭配微软雅黑的话，把 monospace 删去即可，况且它在主流系统中完全映射不到。

## 修改前：
<img width="1920" alt="serif" src="https://user-images.githubusercontent.com/22417867/176980628-60c1d6ef-3909-40b8-b042-3aa83373ac41.png">

## 修改后：
<img width="1920" alt="sans" src="https://user-images.githubusercontent.com/22417867/176980632-37a46cec-6b36-49ef-92dc-5de3e2c0e5e0.png">

另外日志显示页面还共用了配置编辑器的 font size，在此还有个建议：

/luci-app-openclash/luasrc/view/openclash/config_editor.htm 中第 4 行

`font-size: 15px`

改为 13px，与页面其他部分字体尺寸保持一致，Mac 上也不会有大号字造成渲染过粗的问题，看起来比现在要优雅一些。