### PR TITLE
Preventing placeholder conflicts (close #2765)

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/yml_groups_set.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_groups_set.sh
@@ -231,9 +231,9 @@ yml_groups_set()
    
    #名字变化时处理规则部分
    if [ "$name" != "$old_name" ] && [ ! -z "$old_name" ]; then
-      sed -i "s/,${old_name}/,${name}#d/g" "$CONFIG_FILE" 2>/dev/null
-      sed -i "s/: \"${old_name}\"/: \"${name}#d\"/g" "$CONFIG_FILE" 2>/dev/null
-      sed -i "s/return \"${old_name}\"$/return \"${name}#d\"/g" "$CONFIG_FILE" 2>/dev/null
+      sed -i "s/,${old_name}/,${name}#delete_/g" "$CONFIG_FILE" 2>/dev/null
+      sed -i "s/: \"${old_name}\"/: \"${name}#delete_\"/g" "$CONFIG_FILE" 2>/dev/null
+      sed -i "s/return \"${old_name}\"$/return \"${name}#delete_\"/g" "$CONFIG_FILE" 2>/dev/null
       sed -i "s/old_name \'${old_name}\'/old_name \'${name}\'/g" "$CFG_FILE" 2>/dev/null
       config_load "openclash"
    fi
@@ -306,7 +306,7 @@ if [ "$create_config" = "0" ] || [ "$servers_if_update" = "1" ] || [ ! -z "$if_g
       fi
       config_load "openclash"
       config_foreach yml_groups_set "groups"
-      sed -i "s/#d//g" "$CONFIG_FILE" 2>/dev/null
+      sed -i "s/#delete_//g" "$CONFIG_FILE" 2>/dev/null
       rm -rf /tmp/relay_server.list 2>/dev/null
    fi
 fi


### PR DESCRIPTION
A yaml comment string `#dev` with `#d` removed causes a syntax check to fail