### PR TITLE
Update openclash_custom_fake_filter.list

### DIFF
--- a/luci-app-openclash/root/etc/openclash/custom/openclash_custom_fake_filter.list
+++ b/luci-app-openclash/root/etc/openclash/custom/openclash_custom_fake_filter.list
@@ -131,3 +131,5 @@ Mijia Cloud
 #招商银行
 +.cmbchina.com
 +.cmbimg.com
+#AdGuard
+local.adguard.org


### PR DESCRIPTION
AdGuard运行时会让浏览器访问该域名（https://kb.adguard.com/en/general/local-adguard），如果OpenClash关闭了，AdGuard不会更新local.adguard.org的IP地址，导致所有网站无法访问