### PR TITLE
Add Tun interface wait timeout

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1565,7 +1565,7 @@ if [ -n "$FW4" ]; then
       ip link set utun up
 
       LOG_OUT "Tip: Waiting for TUN Interface Start..."
-      while ( [ -n "$(pidof clash)" ] && [ -z "$(ip route list |grep utun)" ] && [ "$TUN_WAIT" -le 10 ] )
+      while ( [ -n "$(pidof clash)" ] && [ -z "$(ip route list |grep utun)" ] && [ "$TUN_WAIT" -le 30 ] )
       do
          ip link set utun up
          let TUN_WAIT++
@@ -2238,7 +2238,7 @@ else
       ip link set utun up
 
       LOG_OUT "Tip: Waiting for TUN Interface Start..."
-      while ( [ -n "$(pidof clash)" ] && [ -z "$(ip route list |grep utun)" ] && [ "$TUN_WAIT" -le 10 ] )
+      while ( [ -n "$(pidof clash)" ] && [ -z "$(ip route list |grep utun)" ] && [ "$TUN_WAIT" -le 30 ] )
       do
          ip link set utun up
          let TUN_WAIT++


### PR DESCRIPTION
现在等待 TUN 接口启动的 20 秒超时对于某些设备来说有点慢了（特别是 Meta 使用 GEOIPDATA 和 GEOSITE 的情况下），而且超时了没有任何提示，连失败的原因都不知道是什么，建议后续增加相关提示，这里先改为 60 秒。