### PR TITLE
support IPv6 in tun mode

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1828,6 +1828,9 @@ if [ -n "$FW4" ]; then
       modprobe nft_tproxy >/dev/null 2>&1
       ip -6 rule add fwmark "$PROXY_FWMARK" table "$PROXY_ROUTE_TABLE"
       ip -6 route add local ::/0 dev lo table "$PROXY_ROUTE_TABLE"
+      if [ -n "$en_mode_tun" ]; then
+         ip -6 route replace default dev utun table "$PROXY_ROUTE_TABLE"
+      fi
       
       #Google dns
       nft insert rule inet fw4 dstnat position 0 ip6 daddr { 2001:4860:4860::8888, 2001:4860:4860::8844 } tcp dport 53 counter accept comment \"OpenClash Google DNS Hijack\" 2>/dev/null
@@ -2503,6 +2506,9 @@ else
       modprobe xt_TPROXY >/dev/null 2>&1
       ip -6 rule add fwmark "$PROXY_FWMARK" table "$PROXY_ROUTE_TABLE"
       ip -6 route add local ::/0 dev lo table "$PROXY_ROUTE_TABLE"
+      if [ -n "$en_mode_tun" ]; then
+         ip -6 route replace default dev utun table "$PROXY_ROUTE_TABLE"
+      fi
       
       #Google dns
       ip6tables -t nat -I PREROUTING -m comment --comment "OpenClash Google DNS Hijack" -p tcp -d 2001:4860:4860::8888 --dport 53 -j ACCEPT


### PR DESCRIPTION
tun 模式下，目前路由表依然会将 IPv6 包路由到 lo 设备。
这个更改使得 tun 模式下 IPv6 包能被正确地路由到 utun 设备上。
由于Clash Premium 核心的 tun 实现本身并不支持 IPv6，所以还需配合更换 meta core 才能实现 tun 模式下的 IPv6 代理。