### PR TITLE
fix: overwrite  url-test interval not work

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/yml_rules_change.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_rules_change.sh
@@ -822,7 +822,7 @@ yml_other_set()
          Value['proxy-groups'].each{
             |x|
                if x['type'] == 'url-test' then
-                  x['tolerance']='${tolerance}';
+                  x['tolerance']=${tolerance};
                end
             };
       end;
@@ -839,7 +839,7 @@ yml_other_set()
             Value['proxy-groups'].each{
                |x|
                if x['type'] == 'url-test' or x['type'] == 'fallback' or x['type'] == 'load-balance' then
-                  x['interval']='${urltest_interval_mod}';
+                  x['interval']=${urltest_interval_mod};
                end
             };
          end;
@@ -847,7 +847,7 @@ yml_other_set()
             Value['proxy-providers'].values.each{
                |x|
                if x['health-check'] and x['health-check']['enable'] and x['health-check']['enable'] == 'true' then
-                  x['health-check']['interval']='${urltest_interval_mod}';
+                  x['health-check']['interval']=${urltest_interval_mod};
                end;
             };
          end;


### PR DESCRIPTION
解决覆写URL-Test 策略组切换灵敏度(ms)、测速（连通性）间隔修改(s) 不生效的问题。
时间不够，没去研究clash源码，大概率是这个问题。由于加了 ```‘ ’``` 导致读取yaml时类型不对，导致失效。会出现每次url-test都会切换节点。网络就不稳定了。