### PR TITLE
fix: #3296 bad indentation of smux

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/yml_proxys_set.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_proxys_set.sh
@@ -1212,8 +1212,8 @@ EOF
 #Multiplex
    if [ ! -z "$multiplex" ]; then
 cat >> "$SERVER_FILE" <<-EOF
-  smux:
-    enabled: $multiplex
+    smux:
+      enabled: $multiplex
 EOF
       if [ -n "$multiplex_protocol" ]; then
 cat >> "$SERVER_FILE" <<-EOF


### PR DESCRIPTION
close: #3296

before:

```yaml
proxies:
  - type: vmess
    alterId: 0
    cipher: auto
    udp: false
    global-padding: false
    authenticated-length: false
    skip-cert-verify: true
    tls: false
    ip-version: "dual"
    tfo: false
  smux:
    enabled: false
```

Linter error:
```
Error : bad indentation of a mapping entry at line 12, column 3:
      smux:
      ^
Line : undefined  undefined
```

After:

```yaml
proxies:
  - type: vmess
    alterId: 0
    cipher: auto
    udp: false
    global-padding: false
    authenticated-length: false
    skip-cert-verify: true
    tls: false
    ip-version: "dual"
    tfo: false
    smux:
      enabled: false
```
