### PR TITLE
fix: accessibility in dark mode

### DIFF
--- a/luci-app-openclash/luasrc/view/openclash/sub_info_show.htm
+++ b/luci-app-openclash/luasrc/view/openclash/sub_info_show.htm
@@ -12,6 +12,7 @@
 .sub_tab_show{
 	display: inline-block;
 	white-space: nowrap;
+	color: var(--gray-dark);
 	font-size: 12px;
 	margin: 0 auto;
 	-webkit-transition: all 1.5s;


### PR DESCRIPTION
### How to reproduce

Switch your operating system to dark mode.

### Current behavior

![2023-05-27 at 10 43 32@2x](https://github.com/vernesong/OpenClash/assets/8186898/c9b32521-f9f1-4af9-9e01-72e5842a784e)

### Expected behavior

![2023-05-27 at 10 43 06@2x](https://github.com/vernesong/OpenClash/assets/8186898/66de7e8c-cefe-48bf-a9aa-83c5de9bfc34)

### Notes

I used the color variable `-dark-gray` as its light mode for the font color.
