### PR TITLE
uci-defaults文件，保留用户已有的 "enable" 和"dashboard_password"设置值

### DIFF
--- a/luci-app-openclash/root/etc/uci-defaults/luci-openclash
+++ b/luci-app-openclash/root/etc/uci-defaults/luci-openclash
@@ -45,7 +45,9 @@ cat > "/lib/upgrade/keep.d/luci-app-openclash" <<-EOF
 EOF
 
 #Set Dashboard Secret
-uci -q set openclash.config.dashboard_password="$(tr -cd 'a-zA-Z0-9' </dev/urandom 2>/dev/null| head -c8 || date +%N| md5sum |head -c8)"
+if [ -z "$(uci -q get openclash.config.dashboard_password)" ]; then
+	uci -q set openclash.config.dashboard_password="$(tr -cd 'a-zA-Z0-9' </dev/urandom 2>/dev/null | head -c8 || date +%N | md5sum | head -c8)"
+fi
 
 #Set authentication
 uci_name_tmp=$(uci add openclash authentication)
@@ -129,7 +131,11 @@ if [ -f "/tmp/openclash.bak" ]; then
 	rm -rf "/tmp/openclash.bak" >/dev/null 2>&1
 fi
 
-uci -q set openclash.config.enable=0
+#Set global openclash enable option
+if [ -z "$(uci -q get openclash.config.enable)" ]; then
+	uci -q set openclash.config.enable=0
+fi
+
 uci -q commit openclash
 
 if [ -f "/usr/lib/lua/luci/model/network.lua" ]; then


### PR DESCRIPTION
先通过uci -q get检测enable和dashboard_password的值是否为空，
如果为空：
则按之前的写法enable置0，dashboard_password生成随机密码，
如果不为空：
则不做操作，保留用户原有设置。