### PR TITLE
整理并修改 ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,36 +1,41 @@
 name: Bug报告
-description: Create a report to help us improve
+description: Create a Bug report to help us improve
 title: "[Bug] "
 labels: ["bug"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        如果你可以自己 Debug 并解决的话, 建议您直接提交 PR 或 描述解决方法, 非常感谢!
+
   - type: checkboxes
     id: verify_step
     attributes:
       label: Verify Steps
       description: |
-        在提交之前, 请确认 / Please verify that you've followed these steps.
+        在提交之前，请确认 / Please verify that you've followed these steps.
       options:
         - label: Tracker 我已经在 [Issue Tracker](……/) 中找过我要提出的问题
           required: true
-        - label: Latest 我已经使用最新 Dev 版本测试过，问题依旧存在
+        - label: Branch 我知道 OpenClash 的 Dev 分支切换开关位于插件设置-版本更新中，或者我会手动下载并安装 Dev 分支的 OpenClash
           required: true
-        - label: Core 这是 OpenClash 存在的问题，并非我所使用的 Clash 或 Meta 等内核的特定问题
+        - label: Latest 我已经**使用最新 Dev 版本**测试过，问题依旧存在
           required: true
-        - label: Meaningful 我提交的不是无意义的 催促更新或修复 请求
+        - label: Relevant 我知道 OpenClash 与 内核(Core)、控制面板(Dashboard)、在线订阅转换(Subconverter)等项目之间**无直接关系**，仅相互调用
           required: true
+        - label: Definite 这确实是 OpenClash 出现的问题
+          required: true
+        - label: Contributors 我有能力协助 OpenClash 开发并解决此问题
+          required: false
+        - label: Meaningless 我提交的**是无意义的**催促更新或修复请求
+          required: false
+
   - type: input
     id: openclash_version
     attributes:
       label: OpenClash Version
       description: |
         OpenClash 版本号
-      placeholder: "v0.45.16-beta"
+      placeholder: "v0.0.0-beta"
     validations:
       required: true
+
   - type: dropdown
     id: bug_os
     attributes:
@@ -41,10 +46,23 @@ body:
       options:
         - Official OpenWrt
         - Lean
+        - Immortalwrt
+        - Istoreos
         - Docker
         - Other
     validations:
       required: true
+
+  - type: input
+    id: openwrt_version
+    attributes:
+      label: OpenWrt Version
+      description: |
+        Openwrt 固件版本
+      placeholder: "OpenWrt 0.0.0 r0-0"
+    validations:
+      required: true
+
   - type: dropdown
     id: bug_platform
     attributes:
@@ -60,50 +78,62 @@ body:
         - Linux-armv6
         - Linux-armv7
         - Linux-arm64
+        - Linux-loong64
         - Linux-mips-hardfloat
         - Linux-mips-softfloat
         - Linux-mips64
         - Linux-mips64le
-        - Linux-mipsle-softfloat
         - Linux-mipsle-hardfloat
+        - Linux-mipsle-softfloat
+        - Linux-riscv64
         - Other
         - All
     validations:
       required: true
-  - type: textarea
-    id: reproduce_bug
-    attributes:
-      label: To Reproduce
-      description: |
-        复现此Bug的步骤 / How to reproduce?
-    validations:
-      required: true
+
   - type: textarea
     id: describe_bug
     attributes:
       label: Describe the Bug
       description: |
-        对Bug本身清晰而简洁的描述 / Describe the Bug
+        对 Bug 本身清晰而简洁的描述 / Describe the Bug
     validations:
       required: true
+
+  - type: textarea
+    id: reproduce_bug
+    attributes:
+      label: To Reproduce
+      description: |
+        复现此 Bug 的步骤 / How to reproduce?
+    validations:
+      required: true
+
   - type: textarea
     id: openclash_log
     attributes:
       label: OpenClash Log
       description: |
         在下方附上 OpenClash 调试日志 / OpenClash Debug Log
-        隐私提示: 上传此日志前请注意检查、屏蔽公网IP、节点、密码等相关敏感信息
+        调试日志在插件设置-调试日志中生成，**并非只有运行日志**，如调试日志过长，可作为附件在最下方上传
+        **隐私提示: 上传此日志前请注意检查、屏蔽公网IP、节点、密码等相关敏感信息**
+      placeholder: "我已知晓缺失日志可能会导致开发者无法了解我的情况并降低本issue的处理优先级"
+      render: log
     validations:
       required: true
+
   - type: textarea
     id: openclash_config
     attributes:
       label: OpenClash Config
       description: |
-        在下方附上与Bug相关的系统配置、防火墙规则或环境变量 / System config
+        在下方附上与 Bug 相关的系统配置、防火墙规则或环境变量 / System config
+        非 Clash Yaml 文件
+        **非必填项**
       render: shell
     validations:
       required: false
+
   - type: textarea
     id: excepted_behavior
     attributes:
@@ -112,11 +142,12 @@ body:
         对预期修复后情况的清晰明了的描述 / Expected behavior
     validations:
       required: true
+
   - type: textarea
-    id: screenshots
+    id: additional_context
     attributes:
-      label: Screenshots
+      label: Additional Context
       description: |
-        添加屏幕截图以帮助解释您的问题 / Screenshots
+        在此处添加其它信息或屏幕截图 / Additional Context
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,47 @@
 blank_issues_enabled: false
 
 contact_links:
-  - name: Get help in GitHub Discussions
-    url: https://github.com/vernesong/OpenClash/discussions
-    about: Have a question? Not sure if your issue affects everyone reproducibly? The quickest way to get help is on OpenClash's GitHub Discussions!
+
+  - name: 发表Issue前请先在Issues与Discussions中搜索相关内容
+    url: https://github.com/ryanhanwu/How-To-Ask-Questions-The-Smart-Way/blob/main/README-zh_CN.md#在提问之前
+    about: 请有意义且描述明确的描述问题症状而非你的猜测 问题解决后加个简短的补充说明
+
+  - name: 启动成功后无法访问个别网站 | 启动成功后个别网站不想走代理流量
+    url: https://www.bing.com/search?q=clash+rule+写+教&ensearch=1
+    about: 想要了解clash规则编写相关的问题
+
+  - name: CLASH CORE | PERIUM CORE & 内核问题 | 节点协议加密方式 | 规则 | 内核功能建议
+    url: https://github.com/Dreamacro/clash/issues/new/choose
+    about: 原版内核 | P核
+
+  - name: META CORE | MIHOMO CORE & 内核问题 | 节点协议加密方式 | 规则 | 内核功能建议
+    url: https://github.com/MetaCubeX/mihomo/issues/new/choose
+    about: M核
+
+  - name: 在线订阅转换问题 | 在线订阅转换增加节点协议加密方式 | 在线订阅转换功能建议
+    url: https://github.com/tindy2013/subconverter/issues/new/choose
+    about: 提供并增加预设订阅转换服务地址请通过上方 功能请求 发表
+
+  - name: DASHBOARD & 控制面板问题 | 面板功能建议
+    url: https://github.com/Dreamacro/clash-dashboard/issues/new/choose
+    about: 面板问题先请尝试 更换近期未使用过面板设备 或 使用浏览器隐私匿名无痕...模式 访问
+
+  - name: YACD & 控制面板问题 | 面板功能建议
+    url: https://github.com/haishanh/yacd/issues/new/choose
+    about: 面板问题先请尝试 更换近期未使用过面板设备 或 使用浏览器隐私匿名无痕...模式 访问
+
+  - name: METACUBEXD & 控制面板问题 | 面板功能建议
+    url: https://github.com/MetaCubeX/metacubexd/issues/new/choose
+    about: 面板问题先请尝试 更换近期未使用过面板设备 或 使用浏览器隐私匿名无痕...模式 访问
+
+  - name: YACD-META & 控制面板问题 | 面板功能建议
+    url: https://github.com/MetaCubeX/Yacd-meta/issues/new/choose
+    about: 面板问题先请尝试 更换近期未使用过面板设备 或 使用浏览器隐私匿名无痕...模式 访问
+
+  - name: DASHBOARD-META & 控制面板问题 | 面板功能建议
+    url: https://github.com/MetaCubeX/Razord-meta/issues/new/choose
+    about: 面板问题先请尝试 更换近期未使用过面板设备 或 使用浏览器隐私匿名无痕...模式 访问
+
+  - name: 我想讨论OpenClash的某个功能 | 我不确定是什么问题 | 我的问题不属于上述选项 | 我的问题无法得到原作者原仓库的帮助
+    url: https://github.com/vernesong/OpenClash/discussions/new/choose
+    about: 礼多人不怪 而且有时还很有帮助

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,10 +3,7 @@ description: Suggest an idea for this project
 title: "[Feature] "
 labels: [enhancement]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        如果你可以自己 编程实现 的话, 建议您直接提交 PR 或 描述解决方法, 非常感谢!
+
   - type: checkboxes
     id: verify_step
     attributes:
@@ -15,37 +12,29 @@ body:
       options:
         - label: Tracker 我已经在 [Issue Tracker](……/) 中找过我要提出的问题
           required: true
-        - label: Need 当前 OpenClash 并不包含该功能特性或者还不完善
+        - label: Latest 我已经**使用最新 Dev 版本**查看过，并不包含该功能特性或者还不完善
           required: true
-        - label: Framework 这是 OpenClash 应包含的特性, 并非 Clash 特性
+        - label: Relevant 我知道 OpenClash 与 内核(Core)、控制面板(Dashboard)、在线订阅转换(Subconverter)等项目之间**无直接关系**，仅相互调用
           required: true
-        - label: Meaningful 我提交的不是无意义的 催促更新或修复 请求
+        - label: Definite 这确实是 OpenClash 应包含的特性
           required: true
+        - label: Contributors 我有能力协助 OpenClash 开发或完善此功能特性
+          required: false
+        - label: Meaningless 我提交的**是无意义的**催促更新或修复请求
+          required: false
+
   - type: textarea
     attributes:
       label: Describe the Feature
       description: |
-        对问题本身清晰而简洁的描述. 例如这个问题如何影响到你? 目前 OpenClash 的行为是什么? 
+         清晰明了地描述您的想法. 例如你想实现什么 Feature 特性或功能? 如何实现该功能? 目前 OpenClash 的行为是什么?
     validations:
       required: true
-  - type: textarea
-    attributes:
-      label: Describe the Solution
-      description: |
-        清晰明了地描述您的解决方案. 例如你想实现什么 Feature 特性或功能? 如何实现该功能? 
-    validations:
-      required: true
+
   - type: textarea
     attributes:
       label: Describe Alternatives
       description: |
         对您考虑过的任何替代解决方案或备选功能进行清晰、简洁的描述.
-    validations:
-      required: false
-  - type: textarea
-    attributes:
-      label: Additional Context
-      description: |
-        在此处添加关于功能请求的任何其他描述或屏幕截图.
     validations:
       required: false


### PR DESCRIPTION
ISSUE_TEMPLATE 大致修改内容
1. 新建issue时增加了分流，目的可以理解成间接告知用户 OpenClash 和 Clash 等项目的关系，减少一些无意义的issue
2. 两个模板均修改了确认项，顺便挖了个坑，间接促使用户认真对待自己的issue
3. feature模板仅保留一个必填和一个选填，原本的两必填两选填没用户用到的同时也导致issue排版混乱
4. bug模板增加了调试日志的获取方式，填入内容改成了代码块并增加一些说明，防止issue排版混乱，并要求用户认真对待
5. bug模板调换了描述bug和复现bug的顺序
6. bug模板系统环境方面增加了点内容
7. 提高Disscuss的利用率