### PR TITLE
fix add_utun_firewall_zone

### DIFF
--- a/luci-app-openclash/root/etc/uci-defaults/luci-openclash
+++ b/luci-app-openclash/root/etc/uci-defaults/luci-openclash
@@ -204,7 +204,7 @@ add_utun_firewall_zone()
 	config_get "name" "$section" "name" ""
 	config_get "network" "$section" "network" ""
 	if [ "$name" = "lan" ] && [ -z "$(echo $network |grep utun)" ]; then
-		uci -q set firewall."$section".network="$network utun"
+		uci -q add_list firewall."$section".network="utun"
 		uci -q commit firewall
 	fi
 }


### PR DESCRIPTION
修正将utun添加到防火墙区域的方式
使用`uci add_list`而不是`uci set`