### PR TITLE
Remove the 'g' prefix from clash meta's version

### DIFF
--- a/.github/workflows/compile_meta_core.yml
+++ b/.github/workflows/compile_meta_core.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Get Upstream Version
         id: upstream_id
         run: |
-          echo "upstream_id=alpha-g$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "upstream_id: alpha-g$(git rev-parse --short HEAD)"
+          echo "upstream_id=alpha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "upstream_id: alpha-$(git rev-parse --short HEAD)"
 
   Compile:
     runs-on: ubuntu-latest


### PR DESCRIPTION
我发现clash meta版本前会多一个'g'，想问下这个是故意的吗？我能把它去掉吗😂 已经改好了求review下

我有时候会手动更新一下版本，但手动更新的版本不是'g'开头的，OpenClash就会误以为版本旧了要更新，强迫症受不了😂
