### PR TITLE
config: readjust the fallback group

### DIFF
--- a/luci-app-openclash/root/etc/config/openclash
+++ b/luci-app-openclash/root/etc/config/openclash
@@ -123,88 +123,130 @@ config dns_servers
 	option enabled '1'
 
 config dns_servers
-	option type 'https'
-	option group 'fallback'
-	option ip 'dns.cloudflare.com/dns-query'
 	option enabled '0'
+	option group 'fallback'
+	option ip '9.9.9.9'
+	option type 'udp'
 
 config dns_servers
-	option group 'fallback'
-	option ip 'dns.google'
-	option port '853'
-	option type 'tls'
 	option enabled '0'
+	option group 'fallback'
+	option ip '149.112.112.112'
+	option type 'udp'
 
 config dns_servers
-	option group 'fallback'
-	option type 'https'
-	option ip '1.1.1.1/dns-query'
 	option enabled '0'
+	option group 'fallback'
+	option ip '2620:fe::fe'
+	option type 'udp'
 
 config dns_servers
-	option group 'fallback'
-	option ip '1.1.1.1'
-	option port '853'
-	option type 'tls'
 	option enabled '0'
+	option group 'fallback'
+	option ip '2620:fe::9'
+	option type 'udp'
 
 config dns_servers
 	option enabled '0'
 	option group 'fallback'
 	option ip '8.8.8.8'
-	option port '853'
+	option type 'udp'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip '8.8.4.4'
+	option type 'udp'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip '2001:4860:4860::8888'
+	option type 'udp'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip '2001:4860:4860::8844'
+	option type 'udp'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip '2001:da8::666'
+	option type 'udp'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip 'dns.quad9.net'
 	option type 'tls'
 
 config dns_servers
-	option type 'udp'
-	option group 'fallback'
-	option ip '2001:4860:4860::8888'
-	option port '53'
 	option enabled '0'
+	option group 'fallback'
+	option ip 'dns.google'
+	option type 'tls'
 
 config dns_servers
-	option type 'udp'
-	option group 'fallback'
-	option ip '2001:4860:4860::8844'
-	option port '53'
 	option enabled '0'
+	option group 'fallback'
+	option ip '1.1.1.1'
+	option type 'tls'
 
 config dns_servers
-	option type 'udp'
-	option group 'fallback'
-	option ip '2001:da8::666'
-	option port '53'
 	option enabled '0'
-
-config dns_servers
-	option group 'fallback'
-	option type 'https'
-	option ip 'public.dns.iij.jp/dns-query'
-	option enabled '0'
-
-config dns_servers
-	option group 'fallback'
-	option type 'https'
-	option ip 'jp.tiar.app/dns-query'
-	option enabled '0'
-
-config dns_servers
-	option group 'fallback'
-	option type 'https'
-	option ip 'jp.tiarap.org/dns-query'
-	option enabled '0'
-
-config dns_servers
 	option group 'fallback'
 	option ip 'jp.tiar.app'
 	option type 'tls'
-	option enabled '0'
 
 config dns_servers
+	option enabled '0'
 	option group 'fallback'
 	option ip 'dot.tiar.app'
 	option type 'tls'
+
+config dns_servers
 	option enabled '0'
+	option group 'fallback'
+	option ip 'dns.quad9.net/dns-query'
+	option type 'https'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip 'dns.google/dns-query'
+	option type 'https'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip 'dns.cloudflare.com/dns-query'
+	option type 'https'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip '1.1.1.1/dns-query'
+	option type 'https'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip 'public.dns.iij.jp/dns-query'
+	option type 'https'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip 'jp.tiar.app/dns-query'
+	option type 'https'
+
+config dns_servers
+	option enabled '0'
+	option group 'fallback'
+	option ip 'jp.tiarap.org/dns-query'
+	option type 'https'
 
 config dns_servers
 	option enabled '0'
@@ -245,5 +287,5 @@ config dns_servers
 config dns_servers
 	option enabled '0'
 	option group 'fallback'
-	option type 'https'
 	option ip 'doh.mullvad.net/dns-query'
+	option type 'https'


### PR DESCRIPTION
Here are the changes:
remove option port
They all use standard ports, so reassigning ports is not necessary

add quad9-DNS to the fallback group

add google DoH to the fallback group

rearrange the order by option type

change to udp type
google dns of tls type already exists

reorder option to the fallback group