### PR TITLE
feat: support port range in common_ports

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1306,7 +1306,7 @@ if [ -n "$FW4" ]; then
 
    #common ports
    if [ -n "$common_ports" ] && [ "$common_ports" != "0" ]; then
-      nft 'add set inet fw4 common_ports { type inet_service; }'
+      nft 'add set inet fw4 common_ports { type inet_service; flags interval; }'
       for i in $common_port; do
          nft add element inet fw4 common_ports { "$i" }
       done


### PR DESCRIPTION
当前如果想添加端口范围会报错

root@ImmortalWrt:~# nft add element inet fw4 common_ports { "0-3477" } Error: You must add 'flags interval' to your set declaration if you want to add range elements add element inet fw4 common_ports { 0-3477 }
                                    ^^^^^^

添加 flags interval;  以后即可正常添加端口范围，且兼容原来的配置方法

设置常用端口  0-3477, 3479-65534, 65535 后的结果

        set common_ports {
                type inet_service
                flags interval
                elements = { 0-3477, 3479-65534, 65535 }
        }