### PR TITLE
luci-app-openclash: adapt to openwrt official dnsmasq modifiy.

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -14,7 +14,13 @@ BACKUP_FILE="/etc/openclash/backup/$(uci -q get openclash.config.config_path |aw
 CONFIG_FILE="/etc/openclash/$(uci -q get openclash.config.config_path |awk -F '/' '{print $5}' 2>/dev/null)"
 TMP_CONFIG_FILE="/tmp/yaml_config_tmp_$(uci -q get openclash.config.config_path |awk -F '/' '{print $5}' 2>/dev/null)"
 FW4=$(command -v fw4)
-DNSMASQ_CONF_DIR=$(uci -q get dhcp.@dnsmasq[0].confdir || echo '/tmp/dnsmasq.d')
+# Get the default DNSMasq config ID from the UCI configuration
+DEFAULT_DNSMASQ_CFGID=$(uci show dhcp.@dnsmasq[0] | awk -F '.' '{print $2}' | awk -F '=' '{print $1}' | head -1)
+# Locate the dnsmasq.conf file that contains the conf-dir option
+DNSMASQ_CONF_PATH=$(grep -l "^conf-dir=" "/tmp/etc/dnsmasq.conf.${DEFAULT_DNSMASQ_CFGID}")
+# Extract the directory path from the conf-dir line
+DNSMASQ_CONF_DIR=$(grep '^conf-dir=' "$DNSMASQ_CONF_PATH" | cut -d'=' -f2 | head -n 1)
+# Check if a conf-dir value was found and set variables accordingly
 DNSMASQ_CONF_DIR=${DNSMASQ_CONF_DIR%*/}
 }
 CLASH="/etc/openclash/clash"


### PR DESCRIPTION
1、官方dnsmasq路径已变更为：/tmp/dnsmasq.cfgxxxxx.d（xxxxx为dnsmasq生成的配置ID），而目前openclash默认dnsmasq的路径为：/tmp/dnsmasq.d，如不做修改，会导致dns无法解析引起插件可正常运行但节点连接失败。 
2、lede等旧版本的dnsmasq的路径仍为：/tmp/dnsmasq.d，考虑到此情况，本次修改自动判断官方和lede等新旧版本的dnsmasq路径，以便正确实现dns解析，并使节点正常链接。