### PR TITLE
fix: save file after ruby_delete()

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/ruby.sh
+++ b/luci-app-openclash/root/usr/share/openclash/ruby.sh
@@ -149,6 +149,6 @@ local Value RUBY_YAML_PARSE
 if [ -z "$1" ] || [ -z "$3" ]; then
 	return
 fi
-RUBY_YAML_PARSE="Thread.new{Value = YAML.load_file('$1'); Value$2.delete('$3')}.join"
+RUBY_YAML_PARSE="Thread.new{Value = YAML.load_file('$1'); Value$2.delete('$3'); File.open('$1','w') {|f| YAML.dump(Value, f)}}.join"
 ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "$RUBY_YAML_PARSE" 2>/dev/null
 }


### PR DESCRIPTION
`root/usr/share/openclash/ruby.sh` 中的 `ruby_delete()` 方法在删除后未保存文件