### PR TITLE
luci-app-openclash: Fix `$` sign not escaping correctly.

### DIFF
--- a/luci-app-openclash/Makefile
+++ b/luci-app-openclash/Makefile
@@ -122,13 +122,13 @@ endef
 
 define Package/$(PKG_NAME)/postrm
 #!/bin/sh
-	DEFAULT_DNSMASQ_CFGID="$(uci -q show "dhcp.@dnsmasq[0]" | awk 'NR==1 {split($0, conf, /[.=]/); print conf[2]}')"
+	DEFAULT_DNSMASQ_CFGID="$$(uci -q show "dhcp.@dnsmasq[0]" | awk 'NR==1 {split($0, conf, /[.=]/); print conf[2]}')"
 	if [ -f "/tmp/etc/dnsmasq.conf.$DEFAULT_DNSMASQ_CFGID" ]; then
-	   DNSMASQ_CONF_DIR="$(awk -F '=' '/^conf-dir=/ {print $2}' "/tmp/etc/dnsmasq.conf.$DEFAULT_DNSMASQ_CFGID")"
+	   DNSMASQ_CONF_DIR="$$(awk -F '=' '/^conf-dir=/ {print $2}' "/tmp/etc/dnsmasq.conf.$DEFAULT_DNSMASQ_CFGID")"
 	else
 	   DNSMASQ_CONF_DIR="/tmp/dnsmasq.d"
 	fi
-	DNSMASQ_CONF_DIR=${DNSMASQ_CONF_DIR%*/}
+	DNSMASQ_CONF_DIR=$${DNSMASQ_CONF_DIR%*/}
 	rm -rf /etc/openclash >/dev/null 2>&1
 	rm -rf /etc/config/openclash >/dev/null 2>&1
 	rm -rf /tmp/openclash.log >/dev/null 2>&1
@@ -152,8 +152,10 @@ define Package/$(PKG_NAME)/postrm
 	sed -i '/.*kB maximum content size*/c\export let HTTP_MAX_CONTENT = 1024*100;		// 100 kB maximum content size' /usr/share/ucode/luci/http.uc >/dev/null 2>&1
 	uci -q delete firewall.openclash
 	uci -q commit firewall
+	[ -f "/etc/config/ucitrack" ] && {
 	uci -q delete ucitrack.@openclash[-1]
 	uci -q commit ucitrack
+	}
 	rm -rf /tmp/luci-*
 	exit 0
 endef


### PR DESCRIPTION
修改前：

![image](https://github.com/user-attachments/assets/3e1c8428-6d27-4fa2-8f00-594a7244797f)

修改后：

![image](https://github.com/user-attachments/assets/e9790998-9554-48f7-a43d-879c277d8f97)

