### PR TITLE
Enhance nft firewall rules; add support for IPv6 suffix matching

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -870,6 +870,7 @@ firewall_rule_exclude()
 
    if [ -n "$(echo $dest_port |grep -E '\-|\:'  2>/dev/null)" ]; then
       LOG_OUT "Warning: Because there is a port range【$dest_port】in the firewall rule settings【$name】auto bypassing may cause the normal connection of the client not to reach the core, if necessary, please add your own in the access control!"
+      return
    fi
 
    if [ -n "$FW4" ]; then

--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -826,7 +826,7 @@ check_core_status()
 firewall_rule_exclude()
 {
    local section="$1"
-   local name src dest dest_port proto target enabled family
+   local name src dest dest_port dest_ip proto target enabled family
 
    config_get "name" "$section" "name" ""
    config_get "src" "$section" "src" ""
@@ -837,6 +837,18 @@ firewall_rule_exclude()
    config_get "target" "$section" "target" ""
    config_get "enabled" "$section" "enabled" ""
    config_get "family" "$section" "family" ""
+
+   ipv6_suffix_to_nft_format() {
+       local ipv6_with_prefix="$1"
+          if [[ "$ipv6_with_prefix" =~ / ]]; then
+             local suffix="${ipv6_with_prefix%%/*}"
+             local prefix="${ipv6_with_prefix##*/}"
+             echo "& $prefix == $suffix"
+          else
+             echo "$ipv6_with_prefix"
+          fi
+   }
+   nft_ipv6=$(ipv6_suffix_to_nft_format "$dest_ip")
 
    if [ a"$target" != aACCEPT  ] || [ a"$enabled" == a0 ]; then
       return
@@ -858,10 +870,11 @@ firewall_rule_exclude()
 
    if [ -n "$(echo $dest_port |grep -E '\-|\:'  2>/dev/null)" ]; then
       LOG_OUT "Warning: Because there is a port range【$dest_port】in the firewall rule settings【$name】auto bypassing may cause the normal connection of the client not to reach the core, if necessary, please add your own in the access control!"
-      return
    fi
 
    if [ -n "$FW4" ]; then
+      dest_ip=$(echo $dest_ip |sed "s/ /,/g" 2>/dev/null)
+
       if [ -z "$family" ] || [ "$family" == "ipv4" ]; then
          if [ -z "$en_mode_tun" ] || [ "$en_mode_tun" -eq 2 ]; then
             for i in $dest_port; do
@@ -911,7 +924,11 @@ firewall_rule_exclude()
                   if [ -z "$dest_ip" ]; then
                      nft insert rule inet fw4 openclash_mangle_v6 position 0 meta nfproto {ipv6} tcp sport "$i" counter return >/dev/null 2>&1
                   else
-                     nft insert rule inet fw4 openclash_mangle_v6 position 0 ip6 saddr { "$dest_ip" } tcp sport "$i" counter return >/dev/null 2>&1
+                     if [[ "$dest_ip" =~ , ]]; then
+                        nft insert rule inet fw4 openclash_mangle_v6 position 0 ip6 saddr { "$dest_ip" } tcp sport "$i" counter return >/dev/null 2>&1
+                     else
+                        nft insert rule inet fw4 openclash_mangle_v6 position 0 ip6 saddr "$nft_ipv6" tcp sport "$i" counter return >/dev/null 2>&1
+                     fi
                   fi
                   nft insert rule inet fw4 openclash_mangle_output_v6 position 0 meta nfproto {ipv6} tcp sport "$i" counter return >/dev/null 2>&1
                fi
@@ -919,13 +936,18 @@ firewall_rule_exclude()
                   if [ -z "$dest_ip" ]; then
                      nft insert rule inet fw4 openclash_mangle_v6 position 0 meta nfproto {ipv6} udp sport "$i" counter return >/dev/null 2>&1
                   else
-                     nft insert rule inet fw4 openclash_mangle_v6 position 0 ip6 saddr { "$dest_ip" } udp sport "$i" counter return >/dev/null 2>&1
+                     if [[ "$dest_ip" =~ , ]]; then
+                        nft insert rule inet fw4 openclash_mangle_v6 position 0 ip6 saddr { "$dest_ip" } udp sport "$i" counter return >/dev/null 2>&1
+                     else
+                        nft insert rule inet fw4 openclash_mangle_v6 position 0 ip6 saddr "$nft_ipv6" udp sport "$i" counter return >/dev/null 2>&1
+                     fi
                   fi
                   nft insert rule inet fw4 openclash_mangle_output_v6 position 0 meta nfproto {ipv6} udp sport "$i" counter return >/dev/null 2>&1
                fi
             done
          fi
       fi
+
    else
       dest_port=$(echo $dest_port |sed "s/-/:/g" 2>/dev/null)
       dest_ip=$(echo $dest_ip |sed "s/ /,/g" 2>/dev/null)


### PR DESCRIPTION
完善nftables防火墙规则的导入，包括添加对IPv6后缀匹配的支持。

1）由于有设备需要开放端口，且公网IPv6的前缀时常变动，我在OpenWrt上添加了匹配IPv6后缀的规则。但OpenClash并没有成功导入这一规则，因为nft规则有特定的格式要求，需要进行转换。以往，有需要的朋友会通过自定义脚本来解决 https://github.com/vernesong/OpenClash/issues/3929 https://github.com/vernesong/OpenClash/issues/3088#issuecomment-1463930866 ，而完善代码后，包含端口的这类规则将可以自动读取。

PS. 目前的代码还不支持导入只有IP没有端口的防火墙规则。这是为什么呢？看起来这意味着openclash_mangle_output(_v6)链要return来自所有端口的流量，这应该会带来问题，但我不太理解为什么要这样。如果能通过其他办法规避问题，我可以试着修改，比如在此情况下只添加openclash_mangle链的规则。

2）如果nft规则中出现多个IP，OpenClash会无法导入该规则，将IP之间的空格改为逗号即可解决。

3）如果nft规则中出现端口范围，OpenClash会无法导入该规则。脚本中提示称这可能影响正常流量经过核心，并将其return，但后续在iptables的相关部分，又存在将端口范围的”-“改成”:“的代码，这还有意义吗？如果根据提示，在”黑白名单“中添加绕过的端口，这将无法区分来源的IP。我觉得有提示已经足够了，直接return可能不符合大家预期的行为。但如果作者有更多考虑，可以将其恢复，我再想其他办法解决问题~

不论如何，非常感谢开发者的辛勤付出！