### PR TITLE
add SAFE_PATHS env for /usr/share/openclash/ui

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -648,6 +648,7 @@ start_run_core()
    chown root:root /etc/openclash/core/* 2>/dev/null
    kill_clash
    procd_open_instance "openclash"
+   procd_set_param env SAFE_PATHS=/usr/share/openclash/ui
    procd_set_param command /bin/sh -c "$CLASH -d $CLASH_CONFIG -f \"$CONFIG_FILE\" >> $LOG_FILE 2>&1"
    procd_set_param user "root"
    procd_set_param group "nogroup"


### PR DESCRIPTION
根据这个 [https://github.com/MetaCubeX/mihomo/releases/tag/v1.19.8](url)，新版本的mihomo客户端会启动失败，因为 /usr/share/openclash/ui，不在/etc/openclash中，通过添加SAFE_PATHS 环境变量可以解决该问题