### PR TITLE
Compatible with OpenWrt SNAPSHOT loading icon

### DIFF
--- a/luci-app-openclash/luasrc/view/openclash/debug.htm
+++ b/luci-app-openclash/luasrc/view/openclash/debug.htm
@@ -96,7 +96,7 @@ local dns_host = "www.instagram.com"
 		if (legend && output)
 		{
 			output.innerHTML =
-				'<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align:middle" /> ' +
+				'<img src="<%=resource%>/icons/loading.svg" onerror="this.onerror=null;this.src=\'<%=resource%>/icons/loading.gif\'" alt="<%:Loading%>" style="vertical-align:middle" /> ' +
 				'<%:Waiting for command to complete...%>';
 
 			legend.parentNode.style.display = 'block';
@@ -139,7 +139,7 @@ local dns_host = "www.instagram.com"
 		if (legend && output)
 		{
 			output.innerHTML =
-				'<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align:middle" /> ' +
+				'<img src="<%=resource%>/icons/loading.svg" onerror="this.onerror=null;this.src=\'<%=resource%>/icons/loading.gif\'" alt="<%:Loading%>" style="vertical-align:middle" /> ' +
 				'<%:Waiting for command to complete...%>';
 
 			legend.parentNode.style.display = 'block';
@@ -176,7 +176,7 @@ local dns_host = "www.instagram.com"
 		if (legend && output)
 		{
 			output.innerHTML =
-				'<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align:middle" /> ' +
+				'<img src="<%=resource%>/icons/loading.svg" onerror="this.onerror=null;this.src=\'<%=resource%>/icons/loading.gif\'" alt="<%:Loading%>" style="vertical-align:middle" /> ' +
 				'<%:Waiting for command to complete...%>';
 
 			legend.parentNode.style.display = 'block';


### PR DESCRIPTION
https://github.com/openwrt/luci/commit/ae5d91da903b6f1d3086d6082ca622231e34f555#diff-af682ce2f349964b9302fd13ee015b2b629eaafef7a93eb49375d2f148a8854d The OpenWrt SNAPSHOT icon has been changed to SVG format; this won't affect versions prior to 24.10-SNAPSHOT.
![2025-06-17_234027_315](https://github.com/user-attachments/assets/75d41541-bf08-4c77-b5bf-7db8f2e00e3d)
![2025-06-17_234121_346](https://github.com/user-attachments/assets/63be52da-89b2-4905-a4e7-0c2f013da17b)
