### PR TITLE
chore: redesign update page ui

### DIFF
--- a/luci-app-openclash/luasrc/view/openclash/update.htm
+++ b/luci-app-openclash/luasrc/view/openclash/update.htm
@@ -4,150 +4,697 @@
 }
 </style>
 
-<fieldset class="cbi-section">
-	<table width="100%">
-	  <tr><td width="100%" colspan="6">
-	    <p align="center" id="update_tip">
-	  		<b><%:Note: if the update fails, you can manually download and upload%></b>
-	  	</p>
-	  </td></tr>
-	  <tr><td width="16.6%" align="right"><%:Compiled Version%></td>
-	  	<td width="16.6%" align="left">
-			<select class="cbi-input-select" name="CORE_VERSION" id="CORE_VERSION">
-	  			<option value="linux-386"><%:linux-386%></option>
-				<option value="linux-amd64-v1"><%:linux-amd64-v1(x86-64)%></option>
-				<option value="linux-amd64-v2"><%:linux-amd64-v2(x86-64)%></option>
-				<option value="linux-amd64-v3"><%:linux-amd64-v3(x86-64)%></option>
-				<option value="linux-armv5"><%:linux-armv5%></option>
-				<option value="linux-armv6"><%:linux-armv6%></option>
-				<option value="linux-armv7"><%:linux-armv7%></option>
-				<option value="linux-arm64"><%:linux-arm64(armv8)%></option>
-				<option value="linux-loong64-abi1"><%:linux-loong64-abi1%></option>
-				<option value="linux-loong64-abi2"><%:linux-loong64-abi2%></option>
-				<option value="linux-riscv64"><%:linux-riscv64%></option>
-				<option value="linux-s390x"><%:linux-s390x%></option>
-				<option value="linux-mips-hardfloat"><%:linux-mips-hardfloat%></option>
-				<option value="linux-mips-softfloat"><%:linux-mips-softfloat%></option>
-				<option value="linux-mips64"><%:linux-mips64%></option>
-				<option value="linux-mips64le"><%:linux-mips64le%></option>
-				<option value="linux-mipsle-softfloat"><%:linux-mipsle-softfloat%></option>
-				<option value="linux-mipsle-hardfloat"><%:linux-mipsle-hardfloat%></option>
-				<option value="0"><%:Not Set%></option>
-	  		</select>
-		</td>
-	  	<td width="16.6%" align="right"><%:Release Branch%></td>
-	  	<td width="16.6%" align="left"><select class="cbi-input-select" name="RELEASE_BRANCH" id="RELEASE_BRANCH">
-	  		<option value="master">Master</option>
-			<option value="dev">Developer</option>
-	  	</select></td>
-		<td width="16.6%" align="right"><%:Smart Core%> <a href="javascript:void(0);" onclick="window.open('https://github.com/vernesong/mihomo/releases', '_blank');" style="color: #0066cc; text-decoration: none;" title="<%:View core infos that support smart group%>"> (?)</a></td>
-	  	<td width="16.6%" align="left"><select class="cbi-input-select" name="SMART_ENABLE" id="SMART_ENABLE">
-	  		<option value="0"><%:Disabled%></option>
-			<option value="1"><%:Enable%></option>
-	  	</select></td>
-	  	</tr>
-	</table>
-</fieldset>
-<fieldset class="cbi-section">
-	<table width="100%">
-		<tr><td width="100%" colspan="4">
-	    <p align="center">
-	  		<b><%:Core Update%></b>
-	  	</p>
-	  	</td></tr>
-	  	<tr><td width="100%" colspan="4">
-		<tr>
-			<td width="25%"><%:CPU Architecture%></td><td width="25%" align="left" id="CPU_MODEL"><%:Collecting data...%></td>
-			<td width="25%"><%:Last Check Update%></td><td width="25%" align="left" id="CHECKTIME"><%:Collecting data...%></td>
-		</tr>
-	  	<tr><td width="100%" colspan="4">
-	    <p align="center">
-	  		<b><%:Core path:%>/etc/openclash/core/clash_meta</b>
-	  	</p>
-	  	</td></tr>
-		<tr><td width="25%">[Meta] <%:Current Core%></td><td width="25%" align="left" id="CORE_META_CV"><%:Collecting data...%></td><td width="25%">[Meta] <%:Latest Core%></td><td width="25%" align="left" id="CORE_META_LV"><%:Collecting data...%></td></tr>
-		<tr><td width="25%"><%:Update Core%></td><td width="25%" align="left" id="core_meta_up"><%:Collecting data...%></td><td width="25%"><%:Download Latest Core%></td><td width="25%" align="left" id="ma_core_meta_up"><%:Collecting data...%></td></tr>
-	</table>
-</fieldset>
-<fieldset class="cbi-section">
-	<table width="100%">
-		<tr><td width="100%" colspan="4">
-	    <p align="center">
-	  		<b><%:Client Update%></b>
-	  	</p>
-	  	</td></tr>
-		<tr><td width="25%"><%:Current Client%></td><td width="25%" align="left" id="OP_CV"><%:Collecting data...%></td><td width="25%"><%:Latest Client%></td><td width="25%" align="left" id="OP_LV"><%:Collecting data...%></td></tr>
-	  	<tr><td width="25%"><%:Update Client%></td><td width="25%" align="left" id="op_up"><%:Collecting data...%></td><td width="25%"><%:Download Latest Client%></td><td width="25%" align="left" id="ma_op_up"><%:Collecting data...%></td></tr>
-	</table>
-</fieldset>
-<fieldset class="cbi-section">
-	<table width="100%">
-	  <tr>
-	  	<td width="33%">
-	  	   <p align="center" id="restore">
-	  		   <%:Collecting data...%>
-	  	   </p>
-	  	</td>
-	  	<td width="33%">
-	  	   <p align="center" id="remove_core">
-	  		   <%:Collecting data...%>
-	  	   </p>
-	  	</td>
-		  <td width="33%">
-			<p align="center" id="one_key_update_cdn">
-				<%:Collecting data...%>
-			</p>
-	   </td>
-	  </tr>
-	</table>
-</fieldset>
-<fieldset class="cbi-section">
-	<table width="100%">
-		<tr><td width="100%" colspan="4">
-	    <p align="center">
-	  		<b><%:Backup Section%></b>
-	  	</p>
-		</td></tr>
-		<tr>
-	  	<td width="25%">
-	  	   <p align="center" id="backup">
-	  		   <%:Collecting data...%>
-	  	   </p>
-	  	</td>
-	  	<td width="25%">
-	  	   <p align="center" id="backup_ex_core">
-	  		   <%:Collecting data...%>
-	  	   </p>
-	  	</td>
-	  	<td width="25%">
-	  	   <p align="center" id="backup_core_only">
-	  		   <%:Collecting data...%>
-	  	   </p>
-	  	</td>
-		</tr>
-		<tr>
-	  	<td width="25%">
-	  	   <p align="center" id="backup_config_only">
-	  		   <%:Collecting data...%>
-	  	   </p>
-	  	</td>
-	  	<td width="25%">
-	  	   <p align="center" id="backup_rule_only">
-	  		   <%:Collecting data...%>
-	  	   </p>
-	  	</td>
-	  	<td width="25%">
-	  	   <p align="center" id="backup_proxy_only">
-	  		   <%:Collecting data...%>
-	  	   </p>
-	  	</td>
-		</tr>
-	</table>
-</fieldset>
+<style>
+    :root {
+        --card-bg: #ffffff;
+        --card-body-bg: #ffffff;
+        --title-bar-bg: #f8f9fa;
+        --text-color: #1f2d-3d;
+        --text-color-light: #718096;
+        --cell-bg-color: #f8f9fa;
+        --label-text-color: #343a40;
+        --border-color: #dee2e6;
+        --shadow-color: rgba(0, 0, 0, 0.075);
+        --link-color: #007bff;
+        --title-color: #212529;
+        --tip-bg: #e6f7ff;
+        --tip-border: #91d5ff;
+        --input-bg: #ffffff;
+        --input-border: #ced4da;
+        --btn-primary-bg: #007bff;
+        --btn-primary-hover-bg: #0069d9;
+        --btn-danger-bg: #dc3545;
+        --btn-danger-hover-bg: #c82333;
+        --btn-info-bg: #6c757d;
+        --btn-info-hover-bg: #5a6268;
+        --status-green: #28a745;
+        --status-red: #dc3545;
+        --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+        --primary-color: #3b82f6;
+    }
 
-<script type="text/javascript">//<![CDATA[
-	var core_version = document.getElementById('CORE_VERSION');
- 	var checktime = document.getElementById('CHECKTIME');
+    .oc-container {
+        display: grid;
+        gap: 6px;
+    }
+
+    .oc-card {
+        background-color: var(--card-bg);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 0.125rem 0.25rem var(--shadow-color);
+        display: flex;
+        flex-direction: column;
+        transition: all 0.3s ease-in-out;
+        padding: 0;
+        overflow: hidden;
+    }
+
+    .oc-card-body {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
+        padding: 0.375rem;
+        background-color: var(--card-body-bg);
+    }
+
+    .oc-card-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--title-color);
+        margin: 0;
+        text-align: left;
+        padding: 0.75rem 1.25rem;
+        background-color: var(--title-bar-bg);
+        border-bottom: 1px solid var(--border-color);
+    }
+    
+    #update_tip { text-align: center; padding: 0.75rem; border-radius: 0.375rem; background-color: var(--tip-bg); font-weight: 500; border: 1px solid var(--tip-border); margin: 0.5rem auto; grid-column: 1 / -1; }
+
+    .cbi-input-select {
+        box-sizing: border-box;
+        width: 100%;
+        padding: 0.375rem;
+        border: 1px solid var(--input-border);
+        border-radius: 0.25rem;
+        background-color: var(--input-bg);
+        color: var(--text-color);
+        line-height: 1.5;
+    }
+
+    .oc-btn { display: inline-block; width: 100%; padding: 0.75rem 1rem; border: 1px solid transparent !important; border-radius: 0.25rem; font-weight: 600; font-size: 0.9rem; color: #fff !important; text-align: center; cursor: pointer; transition: all 0.2s ease-in-out; }
+    .oc-btn:active { transform: scale(0.98); }
+    
+    .oc-btn-primary { background-color: var(--btn-primary-bg) !important; }
+    .oc-btn-primary:hover { background-color: var(--btn-primary-hover-bg) !important; }
+    .oc-btn-danger { background-color: var(--btn-danger-bg) !important; }
+    .oc-btn-danger:hover { background-color: var(--btn-danger-hover-bg) !important; }
+    .oc-btn-info { background-color: var(--btn-info-bg) !important; }
+    .oc-btn-info:hover { background-color: var(--btn-info-hover-bg) !important; }
+    
+    .oc-action-grid { display: grid; gap: 0.5rem; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
+    
+    .info-link { color: var(--link-color); text-decoration: none; font-weight: 600; }
+    
+    .info-cell-value .green { color: var(--status-green) !important; }
+    .info-cell-value .red { color: var(--status-red) !important; }
+
+    .info-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        grid-auto-rows: 1fr;
+        gap: 0.5rem;
+        flex-grow: 1;
+    }
+    .info-cell {
+        background-color: var(--cell-bg-color);
+        padding: 0.7rem;
+        border-radius: 0.75rem;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
+        gap: 0.75rem;
+        position: relative;
+    }
+    .info-cell-title {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--text-color-light);
+    }
+    .info-cell-value b {
+        position: relative;
+        font-size: 14px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        max-width: 100%;
+        display: inline-block;
+        width: auto;
+        padding: 0.4rem 0.8rem;
+        border-radius: 0.375rem;
+        font-family: var(--font-family-base);
+        font-weight: 500;
+        line-height: 1.5;
+        background-color: #fff;
+        border: 1px solid var(--border-color);
+        box-sizing: border-box;
+    }
+    .info-cell-value .oc-btn { width: auto; padding: 0.5rem 1.5rem; }
+    .action-row { display: flex; gap: 0.5rem; align-items: center; justify-content: center; width: 100%; }
+    .action-row > div:first-child { flex-grow: 1; }
+    
+    #core-update-card #show-core-path-btn {
+        width: 42px;
+        padding: 0;
+        font-size: 1.2rem;
+        line-height: 1;
+        flex-shrink: 0;
+    }
+    
+    #core_meta_up, #op_up {
+        padding-left: calc((42px + 0.5rem) / 2);
+        padding-right: calc((42px + 0.5rem) / 2);
+        box-sizing: border-box;
+    }
+
+    .settings-cell {
+        background-color: var(--cell-bg-color);
+        padding: 1.25rem;
+        border-radius: 0.75rem;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 1rem;
+        height: 100%;
+        box-sizing: border-box;
+        text-align: center;
+    }
+    .settings-cell label, .settings-cell .cell-title {
+        color: var(--text-color-light) !important;
+        font-weight: 600;
+        padding: 0;
+        text-align: center;
+        font-size: 12px;
+    }
+    .settings-cell .value {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+    }
+    .settings-cell .cbi-input-select {
+        font-size: 12px;
+    }
+    .settings-cell .cbi-input-select,
+    .settings-cell .segmented-control {
+        width: 100%;
+        max-width: 220px;
+    }
+    .settings-cell .info-cell-value {
+        font-weight: normal;
+    }
+
+    .info-cell.update-available .info-cell-value b {
+        padding-right: 22px;
+    }
+
+    .info-cell.update-available .info-cell-value b::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        right: 8px;
+        transform: translateY(-50%);
+        width: 8px;
+        height: 8px;
+        background-color: var(--status-red);
+        border-radius: 50%;
+        animation: breathing-dot 2s infinite;
+    }
+    @keyframes breathing-dot {
+        0% { box-shadow: 0 0 0 0 rgba(220, 53, 69, 0.7); }
+        70% { box-shadow: 0 0 0 8px rgba(220, 53, 69, 0); }
+        100% { box-shadow: 0 0 0 0 rgba(220, 53, 69, 0); }
+    }
+    
+    .core-settings-layout {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        flex: 1;
+    }
+    .core-settings-bottom {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 0.5rem;
+        flex: 1;
+    }
+    .core-settings-col {
+        display: grid;
+        gap: 0.5rem;
+        grid-auto-rows: 1fr;
+    }
+    @media (min-width: 390px) {
+        .core-settings-bottom {
+            grid-template-columns: 1fr 1fr;
+        }
+    }
+
+    @media (max-width: 390px) {
+        .info-grid {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    @media (max-width: 768px) {
+        .info-cell-value b {
+            font-size: 11px;
+        }
+    }
+    @media (max-width: 575px) {
+        .info-cell-value b {
+            font-size: 10px;
+        }
+    }
+
+    @media (min-width: 1087px) {
+        .oc-container {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        #core-settings-card {
+            grid-column: 1;
+            grid-row: 1;
+        }
+        #core-status-card {
+            grid-column: 1;
+            grid-row: 2;
+        }
+        #core-update-card {
+            grid-column: 2;
+            grid-row: 1;
+        }
+        #client-update-card {
+            grid-column: 2;
+            grid-row: 2;
+        }
+        #shortcuts-card {
+            grid-column: 1;
+            grid-row: 3;
+        }
+        #backup-card {
+            grid-column: 2;
+            grid-row: 3;
+        }
+    }
+
+    @media (max-width: 1334px) and (min-width: 1024px) {
+        #shortcuts-card .oc-action-grid,
+        #backup-card .oc-action-grid {
+            grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+        }
+        #core-update-card .info-cell,
+        #client-update-card .info-cell {
+            padding: 0.5rem;
+        }
+        #core-update-card .info-cell-value b,
+        #client-update-card .info-cell-value b {
+            padding: 0.2rem 0.4rem;
+        }
+        #core-update-card .info-cell.update-available .info-cell-value b,
+        #client-update-card .info-cell.update-available .info-cell-value b {
+            padding-right: 20px;
+        }
+    }
+    
+    [data-darkmode="true"] {
+        --card-bg: #1f2937;
+        --card-body-bg: #1f2937;
+        --title-bar-bg: #374151;
+        --text-color: #ebebeb;
+        --text-color-light: #d0cfcf;
+        --cell-bg-color: #111827;
+        --label-text-color: #e5e7eb;
+        --border-color: #4b5563;
+        --link-color: #63b3ed;
+        --title-color: #e5e7eb;
+        --tip-bg: #1f2937;
+        --tip-border: #6b7280;
+        --input-bg: #374151;
+        --input-border: #6b7280;
+        --btn-primary-bg: #3b82f6;
+        --btn-danger-bg: #ef4444;
+        --btn-info-bg: #4b5563;
+        --status-green: #34d399;
+        --status-red: #ff7070;
+        --primary-color: #3b82f6;
+    }
+    [data-darkmode="true"] .info-cell-value b { background-color: #000000; border-color: #4a5568; }
+
+    #shortcuts-card .oc-btn,
+    #backup-card .oc-btn,
+    #core-update-card .oc-btn,
+    #client-update-card .oc-btn {
+        font-size: 11px !important;
+        font-weight: 500 !important;
+        color: white !important;
+        cursor: pointer !important;
+        border-radius: 0.375rem !important;
+        border: none !important;
+        transition: all 0.15s !important;
+        white-space: normal !important;
+        text-align: center !important;
+        text-decoration: none !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        line-height: 1.2 !important;
+        flex: 1 !important;
+        height: 42px !important;
+        outline: none !important;
+        padding: 2px 10px !important;
+        min-width: 45px;
+        margin: 0 !important;
+        word-break: normal;
+        overflow-wrap: break-word;
+    }
+
+    #shortcuts-card .oc-btn,
+    #backup-card .oc-btn {
+        background-color: #1473e6 !important;
+    }
+</style>
+
+<style>
+    .oc-container *,
+    .oc-container *::before,
+    .oc-container *::after {
+        box-sizing: border-box !important;
+    }
+
+    .oc-btn {
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        padding: 0.6rem 1rem !important;
+        height: 42px !important;
+        font-size: 13px !important;
+        font-weight: 600 !important;
+        color: #ffffff !important;
+        text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25) !important;
+        line-height: 1.2 !important;
+        white-space: nowrap !important;
+        text-align: center !important;
+        border-radius: 6px !important;
+        border: 1px solid rgba(0, 0, 0, 0.2) !important;
+        cursor: pointer !important;
+        outline: none !important;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 1px 2px rgba(0, 0, 0, 0.15) !important;
+        transition: all 0.15s ease-in-out !important;
+    }
+
+    .oc-btn.oc-btn-primary,
+    #shortcuts-card .oc-btn,
+    #backup-card .oc-btn {
+        background: linear-gradient(180deg, #007bff, #0056b3) !important;
+        border-color: #0056b3 !important;
+    }
+
+    .oc-btn.oc-btn-danger {
+        background: linear-gradient(180deg, #e54d42, #c82333) !important;
+        border-color: #c82333 !important;
+    }
+
+    .oc-btn.oc-btn-info {
+        background: linear-gradient(180deg, #6c757d, #545b62) !important;
+        border-color: #545b62 !important;
+    }
+
+    .oc-btn:hover {
+        filter: brightness(1.1);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 2px 4px rgba(0, 0, 0, 0.2) !important;
+        transform: translateY(-1px);
+    }
+
+    .oc-btn:active {
+        transform: translateY(1px) !important;
+        filter: brightness(0.95);
+        box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.2) !important;
+        transition-duration: 0.05s !important;
+    }
+    
+    #core-settings-card .settings-cell .value {
+        width: 100% !important;
+    }
+
+    #core-settings-card .segmented-control {
+        display: flex;
+        background: var(--card-bg);
+        border-radius: 6px;
+        padding: 2px;
+        gap: 2px;
+        position: relative;
+        border: 1px solid var(--border-color);
+        box-shadow: var(--shadow-sm);
+        height: 32px;
+        align-items: center;
+        white-space: nowrap;
+        width: 100% !important;
+        max-width: none !important;
+    }
+
+    #core-settings-card .segmented-indicator {
+        display: none !important;
+    }
+
+    #core-settings-card .segmented-control button {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 5px 10px;
+        font-size: 12px !important;
+        font-weight: 500 !important;
+        color: var(--text-color-light) !important;
+        cursor: pointer;
+        border-radius: 3px !important;
+        transition: all 0.15s ease !important;
+        user-select: none;
+        height: 26px !important;
+        line-height: 1 !important;
+        background-color: transparent !important;
+        border: none !important;
+        transform: none !important;
+    }
+
+    #core-settings-card .segmented-control button:not(.active-text):hover {
+        color: var(--text-color) !important;
+        background: rgba(59, 130, 246, 0.1) !important;
+    }
+
+    #core-settings-card .segmented-control button.active-text {
+        background-color: var(--primary-color) !important;
+        color: #ffffff !important;
+        box-shadow: var(--shadow-sm) !important;
+        transform: none !important;
+    }
+    
+    [data-darkmode="true"] #core-settings-card .segmented-control {
+        background: var(--card-bg);
+    }
+    
+    [data-darkmode="true"] #core-settings-card .segmented-control button:not(.active-text):hover {
+        background-color: rgba(59, 130, 246, 0.1) !important;
+        color: var(--text-color) !important;
+    }
+
+    #shortcuts-card .oc-action-grid,
+    #backup-card .oc-action-grid {
+        display: flex !important;
+        flex-wrap: wrap !important;
+        gap: 8px !important;
+        justify-content: center !important;
+        align-items: stretch !important;
+    }
+    
+    #shortcuts-card .oc-action-grid > div,
+    #backup-card .oc-action-grid > div {
+        flex: 1 1 120px;
+        display: flex !important;
+    }
+
+    #shortcuts-card .oc-btn,
+    #backup-card .oc-btn {
+        width: 100% !important;
+    }
+</style>
+
+
+<p align="center" id="update_tip">
+    <b><%:Note: if the update fails, you can manually download and upload%></b>
+</p>
+
+<div class="oc-container">
+    <div class="oc-card" id="core-settings-card">
+        <h2 class="oc-card-title"><%:Core Settings%></h2>
+        <div class="oc-card-body">
+            <div class="core-settings-layout">
+                <div class="core-settings-top">
+                    <div class="settings-cell">
+                        <label for="CORE_VERSION"><%:Compiled Version%></label>
+                        <div class="value">
+                            <select class="cbi-input-select" name="CORE_VERSION" id="CORE_VERSION"></select>
+                        </div>
+                    </div>
+                </div>
+                <div class="core-settings-bottom">
+                    <div class="settings-cell">
+                        <label><%:Release Branch%></label>
+                        <div class="value">
+                            <select name="RELEASE_BRANCH" id="RELEASE_BRANCH" style="display: none;">
+                                <option value="master">Master</option>
+                                <option value="dev">Developer</option>
+                            </select>
+                            <div class="segmented-control" data-target="RELEASE_BRANCH">
+                                <div class="segmented-indicator"></div>
+                                <button type="button" data-value="master">Master</button>
+                                <button type="button" data-value="dev">Developer</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="settings-cell">
+                        <label>
+                            <%:Smart Core%>&nbsp;<a href="javascript:void(0);" onclick="window.open('https://github.com/vernesong/mihomo/releases', '_blank');" class="info-link" title="<%:View core infos that support smart group%>">(?)</a>
+                        </label>
+                        <div class="value">
+                            <select name="SMART_ENABLE" id="SMART_ENABLE" style="display: none;">
+                                <option value="1"><%:Enable%></option>
+                                <option value="0"><%:Disable%></option>
+                            </select>
+                            <div class="segmented-control" data-target="SMART_ENABLE">
+                                <div class="segmented-indicator"></div>
+                                <button type="button" data-value="1"><%:Enable%></button>
+                                <button type="button" data-value="0"><%:Disable%></button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="oc-card" id="core-status-card">
+        <h2 class="oc-card-title"><%:Core Status%></h2>
+        <div class="oc-card-body">
+            <div class="info-grid">
+                <div class="info-cell">
+                     <div class="info-cell-title"><%:CPU Architecture%></div>
+                     <div class="info-cell-value" id="CPU_MODEL"><%:Collecting data...%></div>
+                </div>
+                <div class="info-cell">
+                     <div class="info-cell-title"><%:Last Check Update%></div>
+                     <div class="info-cell-value" id="CHECKTIME"><%:Collecting data...%></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="oc-card" id="core-update-card">
+        <h2 class="oc-card-title"><%:Core Update%></h2>
+        <div class="oc-card-body">
+            <div class="info-grid">
+                <div class="info-cell">
+                    <div class="info-cell-title">[Meta] <%:Current Core%></div>
+                    <div class="info-cell-value" id="CORE_META_CV"><%:Collecting data...%></div>
+                </div>
+                <div class="info-cell">
+                    <div class="info-cell-title">[Meta] <%:Latest Core%></div>
+                    <div class="info-cell-value" id="CORE_META_LV"><%:Collecting data...%></div>
+                </div>
+                <div class="info-cell">
+                    <div class="info-cell-title"><%:Update Core%></div>
+                    <div class="info-cell-value" id="core_meta_up"><%:Collecting data...%></div>
+                </div>
+                <div class="info-cell">
+                    <div class="info-cell-title"><%:Download Latest Core%></div>
+                    <div class="info-cell-value">
+                        <div class="action-row">
+                            <div id="ma_core_meta_up"><%:Collecting data...%></div>
+                            <div id="core-path-btn-container"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="oc-card" id="client-update-card">
+        <h2 class="oc-card-title"><%:Client Update%></h2>
+        <div class="oc-card-body">
+            <div class="info-grid">
+                <div class="info-cell">
+                    <div class="info-cell-title"><%:Current Client%></div>
+                    <div class="info-cell-value" id="OP_CV"><%:Collecting data...%></div>
+                </div>
+                <div class="info-cell">
+                    <div class="info-cell-title"><%:Latest Client%></div>
+                    <div class="info-cell-value" id="OP_LV"><%:Collecting data...%></div>
+                </div>
+                <div class="info-cell">
+                    <div class="info-cell-title"><%:Update Client%></div>
+                    <div class="info-cell-value" id="op_up"><%:Collecting data...%></div>
+                </div>
+                <div class="info-cell">
+                    <div class="info-cell-title"><%:Download Latest Client%></div>
+                    <div class="info-cell-value" id="ma_op_up"><%:Collecting data...%></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="oc-card" id="shortcuts-card">
+        <h2 class="oc-card-title"><%:Shortcuts%></h2>
+        <div class="oc-card-body">
+            <div class="oc-action-grid">
+                <div id="one_key_update_cdn"></div>
+                <div id="restore"></div>
+                <div id="remove_core"></div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="oc-card" id="backup-card">
+        <h2 class="oc-card-title"><%:Backup%></h2>
+        <div class="oc-card-body">
+            <div class="oc-action-grid">
+                <div id="backup"></div>
+                <div id="backup_ex_core"></div>
+                <div id="backup_core_only"></div>
+                <div id="backup_config_only"></div>
+                <div id="backup_rule_only"></div>
+                <div id="backup_proxy_only"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    function createOptions(selectElement, options) {
+        selectElement.innerHTML = '';
+        options.forEach(function(option) {
+            var opt = document.createElement('option');
+            opt.value = option.value;
+            opt.innerHTML = option.text;
+            selectElement.appendChild(opt);
+        });
+    }
+
+    var coreVersionSelect = document.getElementById('CORE_VERSION');
+    var coreVersionOptions = [
+        {value: "linux-386", text: "<%:linux-386%>"},
+        {value: "linux-amd64-v1", text: "<%:linux-amd64-v1(x86-64)%>"},
+        {value: "linux-amd64-v2", text: "<%:linux-amd64-v2(x86-64)%>"},
+        {value: "linux-amd64-v3", text: "<%:linux-amd64-v3(x86-64)%>"},
+        {value: "linux-armv5", text: "<%:linux-armv5%>"},
+        {value: "linux-armv6", text: "<%:linux-armv6%>"},
+        {value: "linux-armv7", text: "<%:linux-armv7%>"},
+        {value: "linux-arm64", text: "<%:linux-arm64(armv8)%>"},
+        {value: "linux-loong64-abi1", text: "<%:linux-loong64-abi1%>"},
+        {value: "linux-loong64-abi2", text: "<%:linux-loong64-abi2%>"},
+        {value: "linux-riscv64", text: "<%:linux-riscv64%>"},
+        {value: "linux-s390x", text: "<%:linux-s390x%>"},
+        {value: "linux-mips-hardfloat", text: "<%:linux-mips-hardfloat%>"},
+        {value: "linux-mips-softfloat", text: "<%:linux-mips-softfloat%>"},
+        {value: "linux-mips64", text: "<%:linux-mips64%>"},
+        {value: "linux-mips64le", text: "<%:linux-mips64le%>"},
+        {value: "linux-mipsle-softfloat", text: "<%:linux-mipsle-softfloat%>"},
+        {value: "linux-mipsle-hardfloat", text: "<%:linux-mipsle-hardfloat%>"},
+        {value: "0", text: "<%:Not Set%>"}
+    ];
+    createOptions(coreVersionSelect, coreVersionOptions);
+
+	var checktime = document.getElementById('CHECKTIME');
 	var cpu_model = document.getElementById('CPU_MODEL');
 	var core_meta_cv = document.getElementById('CORE_META_CV');
 	var core_meta_lv = document.getElementById('CORE_META_LV');
@@ -169,348 +716,318 @@
 	var remove_core = document.getElementById('remove_core');
 	var release_branch = document.getElementById('RELEASE_BRANCH');
 	var smart_enable = document.getElementById('SMART_ENABLE');
-	core_meta_up.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reload" value="<%:Check And Update%>" onclick="return core_update(this,\'Meta\')"/>';
-	op_up.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reload" value="<%:Check And Update%>" onclick="return op_update(this)"/>';
-	ma_core_meta_up.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reload" value="<%:Download%>" onclick="return ma_core_update(this,\'Meta\')"/>';
-	ma_op_up.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reload" value="<%:Download%>" onclick="return ma_op_update(this)"/>';
-	restore.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Restore Default Config%>" onclick="return restore_config(this)"/>';
-	one_key_update_cdn.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Check Update%>" onclick="return all_one_key_update_cdn(this)"/>';
-	remove_core.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Remove Core%>" onclick="return remove_all_core(this)"/>';
-	backup.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Backup OpenClash%>" onclick="return backup_all_file(this)"/>';
-	backup_ex_core.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Backup Exclude Cores%>" onclick="return backup_no_core(this)"/>';
-	backup_core_only.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Backup Core%>" onclick="return backup_only_core(this)"/>';
-	backup_config_only.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Backup Config%>" onclick="return backup_only_config(this)"/>';
-	backup_rule_only.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Backup Rule Provider%>" onclick="return backup_only_rule(this)"/>';
-	backup_proxy_only.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Backup Proxy Provider%>" onclick="return backup_only_proxy(this)"/>';
+
+	core_meta_up.innerHTML = '<input type="button" class="oc-btn oc-btn-danger" value="<%:Check And Update%>" onclick="return core_update(this,\'Meta\')"/>';
+	op_up.innerHTML = '<input type="button" class="oc-btn oc-btn-danger" value="<%:Check And Update%>" onclick="return op_update(this)"/>';
+	ma_core_meta_up.innerHTML = '<input type="button" class="oc-btn oc-btn-danger" value="<%:Download%>" onclick="return ma_core_update(this,\'Meta\')"/>';
+	ma_op_up.innerHTML = '<input type="button" class="oc-btn oc-btn-danger" value="<%:Download%>" onclick="return ma_op_update(this)"/>';
+	
+	restore.innerHTML = '<input type="button" class="oc-btn oc-btn-primary" value="<%:Restore Default Config%>" onclick="return restore_config(this)"/>';
+	one_key_update_cdn.innerHTML = '<input type="button" class="oc-btn oc-btn-primary" value="<%:Check Update%>" onclick="return all_one_key_update_cdn(this)"/>';
+	remove_core.innerHTML = '<input type="button" class="oc-btn oc-btn-primary" value="<%:Remove Core%>" onclick="return remove_all_core(this)"/>';
+	backup.innerHTML = '<input type="button" class="oc-btn oc-btn-primary" value="<%:Backup OpenClash%>" onclick="return backup_all_file(this)"/>';
+	backup_ex_core.innerHTML = '<input type="button" class="oc-btn oc-btn-primary" value="<%:Backup Exclude Cores%>" onclick="return backup_no_core(this)"/>';
+	backup_core_only.innerHTML = '<input type="button" class="oc-btn oc-btn-primary" value="<%:Backup Core%>" onclick="return backup_only_core(this)"/>';
+	backup_config_only.innerHTML = '<input type="button" class="oc-btn oc-btn-primary" value="<%:Backup Config%>" onclick="return backup_only_config(this)"/>';
+	backup_rule_only.innerHTML = '<input type="button" class="oc-btn oc-btn-primary" value="<%:Backup Rule Provider%>" onclick="return backup_only_rule(this)"/>';
+	backup_proxy_only.innerHTML = '<input type="button" class="oc-btn oc-btn-primary" value="<%:Backup Proxy Provider%>" onclick="return backup_only_proxy(this)"/>';
+
+    var pathBtnContainer = document.getElementById('core-path-btn-container');
+    if (pathBtnContainer) {
+        var pathBtn = document.createElement('button');
+        pathBtn.type = 'button';
+        pathBtn.className = 'oc-btn oc-btn-info';
+        pathBtn.id = 'show-core-path-btn';
+        pathBtn.title = '<%:View Core Path%>';
+        pathBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M4.5 12a.5.5 0 0 0 .5.5h6a.5.5 0 0 0 0-1h-6a.5.5 0 0 0-.5.5zm-2 1.5A2.5 2.5 0 0 1 0 11V5a2.5 2.5 0 0 1 2.5-2.5h11A2.5 2.5 0 0 1 16 5v6a2.5 2.5 0 0 1-2.5 2.5h-11zm11-1a1.5 1.5 0 0 0 1.5-1.5V5a1.5 1.5 0 0 0-1.5-1.5h-11A1.5 1.5 0 0 0 1 5v6a1.5 1.5 0 0 0 1.5 1.5h11z"/><path d="M2.5 4a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5h-11zm0 3a.5.5 0 0 0 0 1h11a.5.5 0 0 0 0-1h-11z"/></svg>';
+        pathBtn.addEventListener('click', function() {
+    		alert('<%:Core Path:%>\n\n/etc/openclash/core/clash_meta');
+    	});
+        pathBtnContainer.appendChild(pathBtn);
+    }
+    
+    var originalTipText = document.getElementById('update_tip').innerHTML;
+    function saveSettings() {
+        var v = coreVersionSelect.value;
+        var r = release_branch.value;
+        var s = smart_enable.value;
+        var tipNode = document.getElementById('update_tip');
+        tipNode.innerHTML = '<b><%:Settings have been saved...%></b>';
+        tipNode.style.borderColor = '#4299e1';
+        
+        XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "save_corever_branch")%>', {core_ver: v, release_branch: r, smart_enable: s}, function(x, status) {
+            setTimeout(function() {
+                tipNode.innerHTML = originalTipText;
+                tipNode.style.borderColor = 'var(--tip-border)';
+            }, 1500);
+        });
+    }
+
+    function setupSegmentedControls() {
+        document.querySelectorAll('.segmented-control').forEach(function(control) {
+            var targetId = control.dataset.target;
+            var targetSelect = document.getElementById(targetId);
+            if (!targetSelect) return;
+
+            var buttons = control.querySelectorAll('button');
+            var indicator = control.querySelector('.segmented-indicator');
+
+            function update() {
+                var currentValue = targetSelect.value;
+                var activeButton = control.querySelector('button[data-value="' + currentValue + '"]');
+                
+                buttons.forEach(function(btn){ btn.classList.remove('active-text'); });
+                
+                if (activeButton) {
+                    activeButton.classList.add('active-text');
+                    var isSecondButton = buttons.length > 1 && activeButton === buttons[1];
+                    if (indicator) {
+                        indicator.style.transform = isSecondButton ? 'translateX(100%)' : 'translateX(0)';
+                    }
+                }
+            }
+
+            buttons.forEach(function(button) {
+                button.addEventListener('click', function() {
+                    if (targetSelect.value !== this.dataset.value) {
+                        targetSelect.value = this.dataset.value;
+                        update();
+                        saveSettings();
+                    }
+                });
+            });
+            update();
+        });
+    }
 
 	XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "update_info")%>', null, function(x, status) {
 		if ( x && x.status == 200 ) {
 			if ( status.corever && status.corever != "0" && status.corever != "" ) {
-		  		core_version.value = status.corever;
-			}
-			else {
-		  		core_version.value = "0";
+		  		coreVersionSelect.value = status.corever;
+			} else {
+		  		coreVersionSelect.value = "0";
 			}
 			if ( status.release_branch && status.release_branch != "" ) {
 		  		release_branch.value = status.release_branch;
-			}
-			else {
+			} else {
 		  		release_branch.value = "master";
 			}
 			if ( status.smart_enable && status.smart_enable != "" ) {
 				smart_enable.value = status.smart_enable;
-			}
-			else {
+			} else {
 				smart_enable.value = "0";
 			}
 		}
 		else {
-			core_version.value = "0";
+			coreVersionSelect.value = "0";
 			release_branch.value = "master";
 			smart_enable.value = "0";
 		}
+        setupSegmentedControls();
 	});
 
-	XHR.poll(300, '<%=luci.dispatcher.build_url("admin", "services", "openclash", "get_last_version")%>', null, function(x, status) {
-	});
+	XHR.poll(300, '<%=luci.dispatcher.build_url("admin", "services", "openclash", "get_last_version")%>', null, function(x, status) {});
 	
 	function updateStatus(x, status) {
         if ( x && x.status == 200 ) {
-            cpu_model.innerHTML = status.coremodel ? "<b style=color:green>"+status.coremodel+"</b>" : "<b style=color:red><%:Model Not Found%></b>";
-            if ( status.upchecktime != "1" ) {
-                checktime.innerHTML = "<b style=color:green>"+status.upchecktime+"</b>";
+            var coreModel = status.coremodel;
+            if (coreModel) {
+                var parts = coreModel.split(' ');
+                if (parts.length >= 2 && parts[0] === parts[1]) {
+                    coreModel = parts[0];
+                }
             }
-            else {
-                checktime.innerHTML = "<b style=color:red><%:Check Failed%></b>";
-            }
-            if ( status.coremetacv == "0" ) {
-                core_meta_cv.innerHTML = "<b style=color:red><%:Unknown%></b>";
-            }
-            else {
-                core_meta_cv.innerHTML = "<b style=color:green>"+status.coremetacv+"</b>";
-            }
+            
+            var elementsToClear = [cpu_model, checktime, core_meta_cv, core_meta_lv, op_cv, op_lv];
+            elementsToClear.forEach(function(el) {
+                if(el) {
+                    el.parentElement.classList.remove('update-available');
+                    while (el.firstChild) { el.removeChild(el.lastChild); }
+                }
+            });
+            
+            var cpu_b = document.createElement('b');
+            if (coreModel) { cpu_b.className = 'green'; cpu_b.textContent = coreModel; }
+            else { cpu_b.className = 'red'; cpu_b.textContent = '<%:Model Not Found%>'; }
+            if (cpu_model) cpu_model.appendChild(cpu_b);
+
+            var checktime_b = document.createElement('b');
+            if ( status.upchecktime != "1" ) { checktime_b.className = 'green'; checktime_b.textContent = status.upchecktime; }
+            else { checktime_b.className = 'red'; checktime_b.textContent = '<%:Check Failed%>'; }
+            if (checktime) checktime.appendChild(checktime_b);
+
+            var core_meta_cv_b = document.createElement('b');
+            if ( status.coremetacv == "0" ) { core_meta_cv_b.className = 'red'; core_meta_cv_b.textContent = '<%:Unknown%>'; }
+            else { core_meta_cv_b.className = 'green'; core_meta_cv_b.textContent = status.coremetacv; }
+            if (core_meta_cv) core_meta_cv.appendChild(core_meta_cv_b);
+
+            var core_meta_lv_b = document.createElement('b');
             var coremetalvis = status.corelv;
             if (coremetalvis != status.coremetacv && coremetalvis != "" && coremetalvis != "loading...") {
-               core_meta_lv.innerHTML = "<b style=color:green>"+coremetalvis+" <%:<New>%></b>";
+               core_meta_lv_b.className = 'green';
+               core_meta_lv_b.textContent = coremetalvis;
+               if (core_meta_lv) core_meta_lv.parentElement.classList.add('update-available');
             }
             else if (coremetalvis != "" && coremetalvis == status.coremetacv && coremetalvis != "loading...") {
-               core_meta_lv.innerHTML = "<b style=color:green>"+coremetalvis+"</b>";
+               core_meta_lv_b.className = 'green';
+               core_meta_lv_b.textContent = coremetalvis;
             }
-            else if (coremetalvis == "loading...") {
-               core_meta_lv.innerHTML = "<b style=color:green><%:Getting Last Version...%></b>";
-            }
-            else {
-               core_meta_lv.innerHTML = "<b style=color:red><%:Unknown%></b>";
-            }
+            else if (coremetalvis == "loading...") { core_meta_lv_b.textContent = '<%:Getting Last Version...%>'; }
+            else { core_meta_lv_b.className = 'red'; core_meta_lv_b.textContent = '<%:Unknown%>'; }
+            if (core_meta_lv) core_meta_lv.appendChild(core_meta_lv_b);
+
+            var op_cv_b = document.createElement('b');
+            if (status.opcv != "0") { op_cv_b.className = 'green'; op_cv_b.textContent = status.opcv; }
+            else { op_cv_b.className = 'red'; op_cv_b.textContent = '<%:Unknown%>'; }
+            if (op_cv) op_cv.appendChild(op_cv_b);
+            
+            var op_lv_b = document.createElement('b');
             var oplv = status.oplv;
-            op_cv.innerHTML = status.opcv != "0" ? "<b style=color:green>"+status.opcv+"</b>" : "<b style=color:red><%:Unknown%></b>";
             if (oplv != "" && oplv != "loading..." && status.opcv != "0") {
                 function compareVersions(v1, v2) {
-                    var ver1 = v1.replace(/^v/, '').split('.');
-                    var ver2 = v2.replace(/^v/, '').split('.');
-                    
-                    var maxLen = Math.max(ver1.length, ver2.length);
+                    var ver1 = v1.replace(/^v/, '').split('.'), ver2 = v2.replace(/^v/, '').split('.'), maxLen = Math.max(ver1.length, ver2.length);
                     while (ver1.length < maxLen) ver1.push('0');
                     while (ver2.length < maxLen) ver2.push('0');
-                    
                     for (var i = 0; i < maxLen; i++) {
-                        var num1 = parseInt(ver1[i], 10);
-                        var num2 = parseInt(ver2[i], 10);
+                        var num1 = parseInt(ver1[i]), num2 = parseInt(ver2[i]);
                         if (num1 > num2) return 1;
                         if (num1 < num2) return -1;
                     }
                     return 0;
                 }
-                
+                op_lv_b.className = 'green';
                 if (compareVersions(oplv, status.opcv) > 0) {
-                    op_lv.innerHTML = "<b style=color:green>"+oplv+" <%:<New>%></b>";
-                } else {
-                    op_lv.innerHTML = "<b style=color:green>"+oplv+"</b>";
+                    op_lv_b.textContent = oplv;
+                    if (op_lv) op_lv.parentElement.classList.add('update-available');
                 }
+                else { op_lv_b.textContent = oplv; }
             }
-            else if (oplv != "" && oplv != "loading...") {
-                op_lv.innerHTML = "<b style=color:green>"+oplv+"</b>";
-            }
-            else if (oplv == "loading...") {
-                op_lv.innerHTML = "<b style=color:green><%:Getting Last Version...%></b>";
-            }
-            else {
-                op_lv.innerHTML = "<b style=color:red><%:Unknown%></b>";
-            }
+            else if (oplv != "" && oplv != "loading...") { op_lv_b.className = 'green'; op_lv_b.textContent = oplv; }
+            else if (oplv == "loading...") { op_lv_b.textContent = '<%:Getting Last Version...%>'; }
+            else { op_lv_b.className = 'red'; op_lv_b.textContent = '<%:Unknown%>'; }
+            if (op_lv) op_lv.appendChild(op_lv_b);
         }
     }
 
     XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "update")%>', null, updateStatus);
-    
     XHR.poll(10, '<%=luci.dispatcher.build_url("admin", "services", "openclash", "update")%>', null, updateStatus);
 
 	function handleStartLog(x, status) {
-        if ( x && x.status == 200 ) {
-            if ( status.startlog == "\n" || status.startlog == "" || status.startlog == "##FINISH##\n" ) {
-                var rdmdl = Math.floor(Math.random()*3)+1;
-                if(rdmdl == 1) {
-                    update_tip.innerHTML = '<b><font><%:Note: if the update fails, you can manually download and upload%></font></b>';
-                }
-                else if(rdmdl == 2) {
-                    update_tip.innerHTML = '<b><font><%:Note: the client may not support update, because the firmware with squashfs format will not release flash space after updating%></font></b>';
-                }
-                else if(rdmdl == 3) {
-                    update_tip.innerHTML = '<b><font><%:Note: options will auto-save when you click to update or download%></font></b>';
-                }
-            }
-            else if ( status.startlog.match("level=fatal") || status.startlog.indexOf("FTL [Config]") != "-1" ) {
-                XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "del_start_log")%>', null, function(x) {});
-                if ( status.startlog.match("level=fatal") ) {
-                    alert('<%:OpenClash Start Failed%> :\n\n' + status.startlog.split('msg=')[1]);
-                }
-                else {
-                    alert('<%:OpenClash Start Failed%> :\n\n' + status.startlog.split('FTL [Config] ')[1]);
-                }
-            }
-            else if ( status.startlog != "\n" && status.startlog != "" && status.startlog != "##FINISH##\n" ) {
-                if ( status.startlog.match("Tip:") || status.startlog.match("提示：")) {
-                    update_tip.innerHTML = '<b style=color:#ff6f00>'+status.startlog+'</b>';
-                }
-                else if ( status.startlog.match("Error:") || status.startlog.match("错误：")) {
-                    update_tip.innerHTML = '<b style=color:#FF0000>'+status.startlog+'</b>';
-                }
-                else if ( status.startlog.match("Warning:") || status.startlog.match("警告：")) {
-                    update_tip.innerHTML = '<b style=color:#ff00bb>'+status.startlog+'</b>';
-                }
-                else if ( status.startlog.match("Watchdog:") || status.startlog.match("守护程序：")) {
-                    update_tip.innerHTML = '<b style=color:#b300ff>'+status.startlog+'</b>';
-                }
-                else {
-                    update_tip.innerHTML = '<b style=color:green>'+status.startlog+'</b>';
-                }
-            }
-        }
-    }
+		if (x && x.status == 200) {
+			if (status.startlog == "\n" || status.startlog == "" || status.startlog == "##FINISH##\n") {
+				const tips = [
+					'<b><font><%:Note: if the update fails, you can manually download and upload%></font></b>',
+					'<b><font><%:Note: the client may not support update, because the firmware with squashfs format will not release flash space after updating%></font></b>',
+					'<b><font><%:Note: options will auto-save when you click to update or download%></font></b>'
+				];
+				update_tip.innerHTML = tips[Math.floor(Math.random() * 3)];
+			}
+			else if (status.startlog.match("level=fatal") || status.startlog.indexOf("FTL [Config]") != -1) {
+				XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "del_start_log")%>', null, function(x) {});
+				alert('<%:OpenClash Start Failed%> :\n\n' +
+					(status.startlog.match("level=fatal") ? status.startlog.split('msg=')[1] : status.startlog.split('FTL [Config] ')[1])
+				);
+			}
+			else if (status.startlog != "\n" && status.startlog != "" && status.startlog != "##FINISH##\n") {
+				let color = "green";
+				if (status.startlog.match("Tip:") || status.startlog.match("提示：")) {
+					color = "#ff6f00";
+				} else if (status.startlog.match("Error:") || status.startlog.match("错误：")) {
+					color = "#FF0000";
+				} else if (status.startlog.match("Warning:") || status.startlog.match("警告：")) {
+					color = "#ff00bb";
+				} else if (status.startlog.match("Watchdog:") || status.startlog.match("守护程序：")) {
+					color = "#b300ff";
+				}
+				update_tip.innerHTML = `<b style=color:${color}>${status.startlog}</b>`;
+			}
+		}
+	}
 
     XHR.poll(3, '<%=luci.dispatcher.build_url("admin", "services", "openclash", "startlog")%>', null, handleStartLog);
 	
-	function core_update(btn,type)
-    {
-    	var v = core_version.value;
-    	var r = release_branch.value;
-		var s = smart_enable.value;
+	function core_update(btn,type) {
+    	var v = coreVersionSelect.value, r = release_branch.value, s = smart_enable.value;
+		btn.disabled = true;
+		btn.value = '<%:Updating...%>';
 		XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "save_corever_branch")%>', {core_ver: v, release_branch: r, smart_enable: s}, function(x, status) {
 			if (x && x.status == 200) {
-				XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "coreupdate")%>', {core_type: type}, function(x, status) {
-					btn.value    = '<%:Check And Update%>';
-					btn.disabled = false;
-					return false;
-				});
-			}
+				XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "coreupdate")%>', {core_type: type}, function(x, status) { btn.value = '<%:Check And Update%>'; btn.disabled = false; });
+			} else { btn.value = '<%:Check And Update%>'; btn.disabled = false; }
 		});
     }
 
-	function op_update(btn)
-    {
-        var v = core_version.value;
-    	var r = release_branch.value;
-		var s = smart_enable.value;
+	function op_update(btn) {
+        var v = coreVersionSelect.value, r = release_branch.value, s = smart_enable.value;
+		btn.disabled = true;
+		btn.value = '<%:Updating...%>';
 		XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "save_corever_branch")%>', {core_ver: v, release_branch: r, smart_enable: s}, function(x, status) {
 			if (x && x.status == 200) {
-				XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "opupdate")%>', null, function(x, status) {
-					btn.value    = '<%:Check And Update%>';
-					btn.disabled = false;
-					return false;
-				});
-			}
+				XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "opupdate")%>', null, function(x, status) { btn.value = '<%:Check And Update%>'; btn.disabled = false; });
+			} else { btn.value = '<%:Check And Update%>'; btn.disabled = false; }
 		});
     }
     
-    function ma_core_update(btn,type)
-    {
-    	var v = core_version.value;
-		var r = release_branch.value;
-		var s = smart_enable.value;
+    function ma_core_update(btn,type) {
+    	var v = coreVersionSelect.value, r = release_branch.value, s = smart_enable.value;
 		XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "save_corever_branch")%>', {core_ver: v, release_branch: r, smart_enable: s}, function(x, status) {
-		if (x && x.status == 200) {
-			btn.value    = '<%:Download%>';
-			btn.disabled = false;
-			XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "update_ma")%>', status.corever, function(x, status) {
-			if ( x && x.status == 200 ) {
-				if ( status.corever != "0" ) {
-					if (type == "Meta") {
-						if (s == "1") {
-							url4='https://raw.githubusercontent.com/vernesong/OpenClash/core/'+r+'/smart/clash-'+status.corever+'.tar.gz';
-							window.location.href=url4;
-						}
-						else {
-							url4='https://raw.githubusercontent.com/vernesong/OpenClash/core/'+r+'/meta/clash-'+status.corever+'.tar.gz';
-							window.location.href=url4;
-						}
-					}
-				}
-				else {
-					alert('<%:No Compiled Version is Selected, Please Select on The Top and Try Again!%>')
-				}
-			}
-       		});
-        return false;
-    	}
+    		if (x && x.status == 200) {
+    			XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "update_ma")%>', {core_type: type}, function(x, status) {
+        			if ( x && x.status == 200 && status.corever && status.corever != "0" ) {
+						var url;
+						if (s == "1") { url ='https://raw.githubusercontent.com/vernesong/OpenClash/core/'+r+'/smart/clash-'+status.corever+'.tar.gz'; }
+                        else { url ='https://raw.githubusercontent.com/vernesong/OpenClash/core/'+r+'/meta/clash-'+status.corever+'.tar.gz'; }
+						window.location.href = url;
+        			} else { alert('<%:No Compiled Version is Selected, Please Select on The Top and Try Again!%>'); }
+           		});
+    		}
       });
     }
     
-    function ma_op_update(btn)
-    {
-        btn.value    = '<%:Download%>';
-        btn.disabled = false;
-        var v = core_version.value;
-		var r = release_branch.value;
-		var s = smart_enable.value;
+    function ma_op_update(btn) {
+        var v = coreVersionSelect.value, r = release_branch.value, s = smart_enable.value;
 		XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "save_corever_branch")%>', {core_ver: v, release_branch: r, smart_enable: s}, function(x, status) {
 			if (x && x.status == 200) {
-				XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "update_ma")%>', status.oplv, function(x, status) {
-					if ( x && x.status == 200 ) {
+				XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "update_ma")%>', null, function(x, status) {
+					if ( x && x.status == 200 && status.oplv && status.oplv != "" && status.oplv != "loading..." ) {
 						var oplv = status.oplv.substring(status.oplv.indexOf("v") + 1);
-						if ( oplv != "" && oplv != "loading..." ) {
-							if (status.pkg_type == "apk") {
-								url2='https://raw.githubusercontent.com/vernesong/OpenClash/package/'+r+'/luci-app-openclash-'+oplv+'.apk';
-							}
-							else {
-								url2='https://raw.githubusercontent.com/vernesong/OpenClash/package/'+r+'/luci-app-openclash_'+oplv+'_all.ipk';
-							}
-							window.location.href=url2;
-						}
-						else {
-							alert('<%:Failed to get the latest version. Please try again later!%>')
-						}
-					}
+						var url;
+						if (status.pkg_type == "apk") { url ='https://raw.githubusercontent.com/vernesong/OpenClash/package/'+r+'/luci-app-openclash-'+oplv+'.apk'; }
+                        else { url ='https://raw.githubusercontent.com/vernesong/OpenClash/package/'+r+'/luci-app-openclash_'+oplv+'_all.ipk'; }
+						window.location.href = url;
+					} else { alert('<%:Failed to get the latest version. Please try again later!%>'); }
 				});
 			}
         });
-        return false; 
     }
     
-    function remove_all_core(btn)
-    {
-        btn.value    = '<%:Remove Core%>';
+    function remove_all_core(btn) {
+		if (!confirm("<%:Are you sure want to remove all core files?%>")) return;
         btn.disabled = true;
-        var r = confirm("<%:Are you sure want to remove all core files?%>")
-        if (r == true) {
         XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "remove_all_core")%>', null, function(x, status) {
-        	if ( x && x.status == 200 ) {
-        		alert('<%:Remove succeeded!%>')
-        	}
-          	else {
-            alert('<%:Remove failed!%>')
-           }
+        	if ( x && x.status == 200 ) { alert('<%:Remove succeeded!%>'); }
+            else { alert('<%:Remove failed!%>'); }
+			btn.disabled = false;
         });
-        } else {
-        }
-        btn.disabled = false;
-        return false; 
     }
     
-    function backup_all_file(btn)
-    {
-		btn.value    = '<%:Backup OpenClash%>';
-		btn.disabled = true;
-		window.location.href='<%="backup"%>';
-		btn.disabled = false;
-		return false; 
-    }
+    function backup_all_file() { window.location.href='<%="backup"%>'; }
+    function backup_no_core() { window.location.href='<%="backup_ex_core"%>'; }
+    function backup_only_core() { window.location.href='<%="backup_only_core"%>'; }
+    function backup_only_config() { window.location.href='<%="backup_only_config"%>'; }
+    function backup_only_rule() { window.location.href='<%="backup_only_rule"%>'; }
+    function backup_only_proxy() { window.location.href='<%="backup_only_proxy"%>'; }
 
-    function backup_no_core(btn)
-    {
-		btn.value    = '<%:Backup Exclude Cores%>';
+	function all_one_key_update_cdn(btn) {
+    	var v = coreVersionSelect.value, r = release_branch.value, s = smart_enable.value;
 		btn.disabled = true;
-		window.location.href='<%="backup_ex_core"%>';
-		btn.disabled = false;
-		return false; 
-    }
-
-    function backup_only_core(btn)
-    {
-		btn.value    = '<%:Backup Core%>';
-		btn.disabled = true;
-		window.location.href='<%="backup_only_core"%>';
-		btn.disabled = false;
-		return false; 
-    }
-
-    function backup_only_config(btn)
-    {
-		btn.value    = '<%:Backup Config%>';
-		btn.disabled = true;
-		window.location.href='<%="backup_only_config"%>';
-		btn.disabled = false;
-		return false; 
-    }
-
-    function backup_only_rule(btn)
-    {
-		btn.value    = '<%:Backup Rule Provider%>';
-		btn.disabled = true;
-		window.location.href='<%="backup_only_rule"%>';
-		btn.disabled = false;
-		return false; 
-    }
-
-    function backup_only_proxy(btn)
-    {
-		btn.value    = '<%:Backup Proxy Provider%>';
-		btn.disabled = true;
-		window.location.href='<%="backup_only_proxy"%>';
-		btn.disabled = false;
-		return false; 
-    }
-
-	function all_one_key_update_cdn(btn)
-    {
-    	var v = core_version.value;
-		var r = release_branch.value;
-		var s = smart_enable.value;
+		btn.value = '<%:Checking...%>';
 		XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "save_corever_branch")%>', {core_ver: v, release_branch: r, smart_enable: s}, function(x, status) {
 			if (x && x.status == 200) {
-				btn.value    = '<%:Check Update%>';
-				btn.disabled = false;
-				return select_git_cdn("one_key_update");
+				select_git_cdn("one_key_update");
 			}
+			btn.value = '<%:Check Update%>';
+			btn.disabled = false;
 		});
     }
-
-//]]></script>
+</script>

--- a/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
+++ b/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
@@ -1374,8 +1374,11 @@ msgstr "当前内核版本"
 msgid "Latest Core"
 msgstr "最新内核版本"
 
-msgid "Core path:"
-msgstr "内核路径："
+msgid "View Core Path"
+msgstr "查看内核路径"
+
+msgid "Core Path:"
+msgstr "内核路径:"
 
 msgid "Update Core"
 msgstr "更新内核"
@@ -4073,3 +4076,27 @@ msgstr "中等版"
 
 msgid "Large Version"
 msgstr "完整版"
+
+msgid "Settings have been saved..."
+msgstr "配置已保存..."
+
+msgid "Core Settings"
+msgstr "核心设置"
+
+msgid "View Core Path"
+msgstr "查看内核路径"
+
+msgid "Core Path:"
+msgstr "内核路径:"
+
+msgid "Enable"
+msgstr "启用"
+
+msgid "Disable"
+msgstr "停用"
+
+msgid "Core Status"
+msgstr "核心状态"
+
+msgid "Shortcuts"
+msgstr "快捷方式"


### PR DESCRIPTION
重构 update.htm 页面，适配手机网页端显示，采用CSS Grid的卡片式布局，改进样式，中文已补全到openclash.zh-cn.po

- 桌面端网页（Argon主题 明亮模式）

<img width="2220" height="955" alt="201" src="https://github.com/user-attachments/assets/a2b6e13d-cc18-4f19-b653-19b93bb8861d" />

- 桌面端网页 （Argon主题 暗色模式）

<img width="2211" height="950" alt="202" src="https://github.com/user-attachments/assets/c752fec5-1bbb-403f-a4a3-65595fa8df0b" />

- 手机端网页（Argon主题 明亮模式）

<img width="1080" height="1707" alt="204 (2)" src="https://github.com/user-attachments/assets/bbf3e948-0c04-44a1-a431-aa404f13e683" />

<img width="1080" height="1540" alt="204 (3)" src="https://github.com/user-attachments/assets/d0811c27-69b7-433c-8f51-443b783b8e4e" />


