### PR TITLE
Fix shell syntax compatibility issue in check_mod function

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -664,8 +664,11 @@ check_mod()
    if container; then
       return 0
    fi
-   
-   if [ -f /proc/config.gz ] && zcat /proc/config.gz | grep -q "CONFIG_${1^^}=y"; then
+
+   # Convert module name to uppercase using POSIX-compatible syntax
+   # BusyBox tr doesn't support [:lower:]/[:upper:], use a-z/A-Z instead
+   module_upper=$(echo "$1" | tr a-z A-Z)
+   if [ -f /proc/config.gz ] && zcat /proc/config.gz | grep -q "CONFIG_${module_upper}=y"; then
       return 0
    fi
    


### PR DESCRIPTION
## Problem

The `check_mod()` function in `/etc/init.d/openclash` uses Bash 4.0+ syntax `${1^^}` to convert module names to uppercase (line 668).

However:
- OpenWrt uses `busybox ash` as `/bin/sh`
- ash doesn't support the `${variable^^}` syntax
- This causes `syntax error: bad substitution`
- Module detection fails even when modules are available

## Impact

Affects systems where kernel modules are compiled as built-in (`CONFIG_xxx=y`):
- ✗ Original code fails to detect `CONFIG_TUN=y` in `/proc/config.gz`
- ✗ Results in false error: "tun module not found"
- ✓ TUN functionality is actually available (`/dev/net/tun` exists)

## Solution

Replace Bash-specific syntax with POSIX-compatible command:
```bash
# Before (Bash 4.0+ only)
if [ -f /proc/config.gz ] && zcat /proc/config.gz | grep -q "CONFIG_${1^^}=y"; then

# After (POSIX compatible)
module_upper=$(echo "$1" | tr a-z A-Z)
if [ -f /proc/config.gz ] && zcat /proc/config.gz | grep -q "CONFIG_${module_upper}=y"; then
```

**Note**: Using `a-z` / `A-Z` instead of `[:lower:]` / `[:upper:]` because BusyBox tr doesn't support character classes.

## Testing

Tested on:
- **System**: iStoreOS 22.03.6
- **Shell**: BusyBox v1.35.0 (ash)
- **Result**: ✅ Successfully detects `CONFIG_TUN=y` in kernel config
- **Verification**: Created test script demonstrating the issue

## Changes

- Modified `check_mod()` function (line 668-672)
- Added POSIX-compatible uppercase conversion
- Added comments explaining the fix
- Minimal, targeted change (3 lines added, 1 line modified)

This fix ensures OpenClash works correctly on all OpenWrt/BusyBox systems with built-in kernel modules.