### PR TITLE
fix(ui): remove default checked state for mode selectors

### DIFF
--- a/luci-app-openclash/luasrc/view/openclash/status.htm
+++ b/luci-app-openclash/luasrc/view/openclash/status.htm
@@ -1710,7 +1710,7 @@
                                     <div class="card-value"><span id="_mode" class="value-indicator"><%:Collecting data...%></span></div>
                                     <div class="card-controls">
                                         <div id="radio-ru-mode" class="cbi-button-group" style="display: inline-flex;">
-                                            <input type="radio" id="normal" name="radios-ru" value="" checked onclick="return switch_run_mode(this.value)"/><label for="normal" id="run_normal" class="cbi-button-option"><%:Compat%></label>
+                                            <input type="radio" id="normal" name="radios-ru" value="" onclick="return switch_run_mode(this.value)"/><label for="normal" id="run_normal" class="cbi-button-option"><%:Compat%></label>
                                             <input type="radio" id="tun" name="radios-ru" value="-tun" onclick="return switch_run_mode(this.value)"/><label for="tun" class="cbi-button-option"><%:TUN%></label>
                                             <input type="radio" id="mix" name="radios-ru" value="-mix" onclick="return switch_run_mode(this.value)"/><label for="mix" class="cbi-button-option"><%:Mix%></label>
                                         </div>
@@ -1722,7 +1722,7 @@
                                 <div class="card-content">
                                     <div class="card-controls">
                                         <div id="radio-mode" class="cbi-button-group" style="display: inline-flex;">
-                                            <input type="radio" id="rule" name="radios" value="rule" checked onclick="return switch_rule_mode(this.value)"/><label for="rule" class="cbi-button-option"><%:Rule%></label>
+                                            <input type="radio" id="rule" name="radios" value="rule" onclick="return switch_rule_mode(this.value)"/><label for="rule" class="cbi-button-option"><%:Rule%></label>
                                             <input type="radio" id="global" name="radios" value="global" onclick="return switch_rule_mode(this.value)"/><label for="global" class="cbi-button-option"><%:Global%></label>
                                             <input type="radio" id="direct" name="radios" value="direct" onclick="return switch_rule_mode(this.value)"/><label for="direct" class="cbi-button-option"><%:Direct%></label>
                                         </div>


### PR DESCRIPTION
## 🐛 问题描述
在数据加载前，Running Mode 和 Proxy Mode 会显示错误的默认选中状态（第一个选项被选中），导致用户看到不准确的信息。

## ✨ 解决方案
移除这两个组件的默认 `checked` 属性，使其与其他设置组件（Area Bypass、Sniffer、DNS Proxy、Stream Unlock）保持一致的行为。

## 📊 修改详情
- 移除 Running Mode 的默认选中状态（行 1713）
- 移除 Proxy Mode 的默认选中状态（行 1725）
- 仅删除 2 个 `checked` 关键字，无其他逻辑修改

## ✅ 效果
修复后，所有 6 个设置组件使用统一的渲染流程，在数据加载前都不会显示错误的默认选中状态。

## 🎨 UI 一致性
修复后的组件列表：
1. Running Mode ✅
2. Proxy Mode ✅
3. Area Bypass ✅
4. Sniffer ✅
5. DNS Proxy ✅
6. Stream Unlock ✅

## 🧪 测试确认
- [x] 页面加载时无默认选中
- [x] 数据返回后正确选中真实状态
- [x] 切换功能正常工作
- [x] 与其他设置组件行为一致