### PR TITLE
feat: support load subscription from config file and support multiple subscription providers display

### DIFF
--- a/luci-app-openclash/luasrc/view/openclash/status.htm
+++ b/luci-app-openclash/luasrc/view/openclash/status.htm
@@ -33,7 +33,7 @@
     --row-1-height: 160px;
     --row-2-height: 140px;
     --row-3-height: 140px;
-    --row-4-height: 250px;
+    --row-4-height: 280px;
 }
 
 .oc[data-darkmode="true"] {
@@ -878,6 +878,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    height: 180px;
     box-shadow: var(--shadow-sm);
     transition: all var(--transition-fast);
     position: relative;
@@ -919,12 +920,13 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
+    margin: auto 0;
 }
 
 .oc .subscription-progress-bar {
     background: var(--bg-gray);
     border-radius: 4px;
-    height: 10px;
+    height: 12px;
     position: relative;
     overflow: hidden;
 }
@@ -945,6 +947,17 @@
 
 .oc .subscription-progress-fill.low {
     background: var(--error-color);
+}
+
+.oc .subscription-info-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    line-height: 1.4;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    display: block;
 }
 
 .oc .subscription-info-text {
@@ -981,7 +994,6 @@
 }
 
 .oc .subscription-providers-grid[data-count="1"] {
-    max-width: 400px;
     overflow-x: hidden;
 }
 
@@ -1452,6 +1464,14 @@
         font-size: 10px;
     }
 
+    .oc .subscription-info-title {
+        font-size: 13px;
+    }
+
+    .oc .subscription-progress-bar {
+        height: 10px;
+    }
+
     .oc .file-info {
         font-size: 10px;
     }
@@ -1615,6 +1635,10 @@
 
     .oc .subscription-info-text {
         font-size: 10px;
+    }
+
+    .oc .subscription-info-title {
+        font-size: 13px;
     }
 
     .oc .config-file-name {
@@ -1906,7 +1930,7 @@
                                                 <polyline points="17,8 12,3 7,8"></polyline>
                                                 <line x1="12" y1="3" x2="12" y2="15"></line>
                                             </svg>
-                                            <%:Upload Config File%>
+                                            <%:Add Config File%>
                                         </button>
                                     </div>
 
@@ -2990,7 +3014,6 @@
             }
 
             if (shouldFetchNew) {
-                // Show loading before fetching
                 this.showLoading();
 
                 StateManager.cachedXHRGetWithParams('<%=luci.dispatcher.build_url("admin", "services", "openclash", "sub_info_get")%>', {filename: filename}, function(x, status) {
@@ -3020,8 +3043,6 @@
             var container = document.getElementById('subscription-info-display');
             var progressSection = document.getElementById('subscription-progress-section');
             var detailsSection = document.getElementById('subscription-info-details');
-            var progressFill = document.getElementById('subscription-progress-fill');
-            var infoText = document.getElementById('subscription-info-text');
 
             if (!container) return;
 
@@ -3034,20 +3055,16 @@
 
             if (data && data.sub_info && data.sub_info !== "No Sub Info Found") {
                 if (data.providers && Array.isArray(data.providers) && data.providers.length > 0) {
-                    if (data.providers.length > 1) {
+                    if (data.providers.length > 1 || data.providers[0].provider_name) {
                         this.displayMultipleProviders(data.providers, progressSection);
                     } else {
-                        this.displaySingleProvider(data.providers[0], progressSection, progressFill, infoText);
+                        this.displaySingleProvider(data.providers[0], progressSection);
                     }
                 } else {
-                    if (progressSection) {
-                        progressSection.style.display = 'none';
-                    }
-                }
-            } else {
-                if (progressSection) {
                     progressSection.style.display = 'none';
                 }
+            } else {
+                progressSection.style.display = 'none';
             }
 
             if (detailsSection) {
@@ -3055,27 +3072,25 @@
             }
         },
 
-        displaySingleProvider: function(provider, progressSection, progressFill, infoText) {
-            if (progressSection) {
-                progressSection.innerHTML = '';
-                progressSection.style.display = 'flex';
-                progressSection.className = 'subscription-progress';
+        displaySingleProvider: function(provider, progressSection) {
+            if (!progressSection) return;
 
-                var progressBar = document.createElement('div');
-                progressBar.className = 'subscription-progress-bar';
+            progressSection.innerHTML = '';
+            progressSection.style.display = 'flex';
+            progressSection.className = 'subscription-progress';
 
-                progressFill = document.createElement('div');
-                progressFill.className = 'subscription-progress-fill';
-                progressBar.appendChild(progressFill);
+            var progressBar = document.createElement('div');
+            progressBar.className = 'subscription-progress-bar';
 
-                infoText = document.createElement('div');
-                infoText.className = 'subscription-info-text';
+            progressFill = document.createElement('div');
+            progressFill.className = 'subscription-progress-fill';
+            progressBar.appendChild(progressFill);
 
-                progressSection.appendChild(progressBar);
-                progressSection.appendChild(infoText);
-            }
+            infoText = document.createElement('div');
+            infoText.className = 'subscription-info-text';
 
-            if (!progressFill || !infoText) return;
+            progressSection.appendChild(progressBar);
+            progressSection.appendChild(infoText);
 
             var percent = parseFloat(provider.percent) || 0;
             var used = String(provider.surplus || provider.used || '0 B');
@@ -3117,11 +3132,17 @@
                 var card = document.createElement('div');
                 card.className = 'provider-card';
 
+                var cardName = document.createElement('div');
+                var providerName = String(provider.provider_name || 'Unknown');
+                cardName.className = 'subscription-info-title';
+                cardName.textContent = providerName;
+                cardName.title = providerName;
+                card.appendChild(cardName);
+
                 var progressBar = document.createElement('div');
                 progressBar.className = 'subscription-progress-bar';
 
                 var progressFill = document.createElement('div');
-                progressFill.className = 'subscription-progress-fill';
                 var percent = parseFloat(provider.percent) || 0;
                 progressFill.style.width = percent + '%';
                 progressFill.className = 'subscription-progress-fill ' +
@@ -3133,7 +3154,6 @@
                 var infoText = document.createElement('div');
                 infoText.className = 'subscription-info-text';
 
-                var providerName = String(provider.provider_name || 'Unknown');
                 var used = String(provider.used || '0 B');
                 var total = String(provider.total || 'N/A');
                 var expire = String(provider.expire || '');
@@ -3184,7 +3204,7 @@
 
                 if (Math.abs(walk) > 5) {
                     hasMoved = true;
-                    e.preventDefault();  // 只在确认拖动时阻止默认行为
+                    e.preventDefault();
                     element.scrollLeft = scrollLeft - walk;
                 }
             };

--- a/luci-app-openclash/luasrc/view/openclash/sub_info_show.htm
+++ b/luci-app-openclash/luasrc/view/openclash/sub_info_show.htm
@@ -17,7 +17,7 @@
     min-width: 0;
 }
 
-.sub_tab{
+.sub_tab {
     display: block;
     white-space: nowrap;
     font-size: 12px;
@@ -29,7 +29,7 @@
     box-sizing: border-box;
 }
 
-.sub_tab_show{
+.sub_tab_show {
     display: block;
     white-space: nowrap;
     font-size: 12px;
@@ -46,7 +46,7 @@
     box-sizing: border-box;
 }
 
-.sub_setting{
+.sub_setting {
     display: inline-block;
     white-space: nowrap;
     margin: 0;
@@ -67,7 +67,7 @@
     opacity: 0.7;
 }
 
-.text_show{
+.text_show {
     color: #333333;
     line-height: 1.2;
 }
@@ -452,15 +452,14 @@ function progressbar_multi_<%=idname%>(providers) {
     var itemWidth;
     var containerClass = 'sub_providers_container';
 
-    // Calculate width based on provider count
     if (providerCount === 2) {
-        itemWidth = 'calc(50% - 2px)';  // 50% minus half of gap
+        itemWidth = 'calc(50% - 2px)';
         containerClass += ' no-scroll';
     } else if (providerCount === 3) {
-        itemWidth = 'calc(33.33% - 2.67px)';  // 33.33% minus gap adjustment
+        itemWidth = 'calc(33.33% - 2.67px)';
         containerClass += ' no-scroll';
     } else {
-        itemWidth = '100px';  // Fixed width for scrolling
+        itemWidth = '100px';
     }
 
     var container = '<div class="' + containerClass + '" id="sub_providers_<%=idname%>">';
@@ -474,11 +473,9 @@ function progressbar_multi_<%=idname%>(providers) {
         var expire = provider.expire || 'null';
         var dayLeft = parseInt(provider.day_left) || 0;
 
-        // Determine background color based on percentage
         var bgColorClass = percent >= 50 ? 'progress_bar_high' :
                           (percent >= 20 ? 'progress_bar_medium' : 'progress_bar_low');
 
-        // Build title for native tooltip
         var titleText = providerName + ': ' + surplus + ' / ' + total + ' (' + percent + '%)';
         if (expire !== 'null' && dayLeft > 0) {
             titleText += ' | ' + dayLeft + ' <%:days%>';
@@ -492,7 +489,6 @@ function progressbar_multi_<%=idname%>(providers) {
 
     container += '</div>';
 
-    // Add drag scroll support after rendering (only for scrollable containers)
     if (providerCount > 3) {
         setTimeout(function() {
             initDragScroll_<%=idname%>();
@@ -512,7 +508,6 @@ function initDragScroll_<%=idname%>() {
     var hasMoved = false;
 
     container.addEventListener('mousedown', function(e) {
-        // 忽略链接和按钮的点击
         if (e.target.tagName === 'A' || e.target.tagName === 'BUTTON') {
             return;
         }
@@ -530,10 +525,9 @@ function initDragScroll_<%=idname%>() {
         var x = e.pageX - container.offsetLeft;
         var walk = (x - startX) * 2;
 
-        // 只有移动距离超过阈值���认为是拖动
         if (Math.abs(walk) > 5) {
             hasMoved = true;
-            e.preventDefault();  // 只在确认拖动时阻止默认行为
+            e.preventDefault();
             container.scrollLeft = scrollLeft - walk;
         }
     });
@@ -562,10 +556,8 @@ function sub_info_refresh_<%=idname%>()
 			localStorage.setItem("sub_info_<%=filename%>",JSON.stringify(status));
 			document.getElementById('<%=idname%>').className = "sub_tab_show";
 
-			// Check if using new providers array format
 			if (status.providers && Array.isArray(status.providers) && status.providers.length > 0) {
 				if (status.providers.length === 1) {
-					// Single provider: use original progressbar format
 					var provider = status.providers[0];
 					document.getElementById('<%=idname%>').innerHTML = progressbar_<%=idname%>(
 						(provider.surplus ? provider.surplus : provider.used),
@@ -576,11 +568,9 @@ function sub_info_refresh_<%=idname%>()
 						(provider.day_left)
 					);
 				} else {
-					// Multiple providers: use new multi-provider layout
 					document.getElementById('<%=idname%>').innerHTML = progressbar_multi_<%=idname%>(status.providers);
 				}
 			} else {
-				// Backward compatibility: old flat format
 				document.getElementById('<%=idname%>').innerHTML = progressbar_<%=idname%>(
 					(status.surplus ? status.surplus : status.used),
 					(status.total),
@@ -626,10 +616,8 @@ function sub_info_get_<%=idname%>()
 			document.getElementById('<%=idname%>').innerHTML = "<span><%:No Sub Info Found%></span>";
 		}
 		else {
-			// Check if using new providers array format
 			if (save_info.providers && Array.isArray(save_info.providers) && save_info.providers.length > 0) {
 				if (save_info.providers.length === 1) {
-					// Single provider: use original progressbar format
 					var provider = save_info.providers[0];
 					document.getElementById('<%=idname%>').innerHTML = progressbar_<%=idname%>(
 						(provider.surplus ? provider.surplus : provider.used),
@@ -640,11 +628,9 @@ function sub_info_get_<%=idname%>()
 						(provider.day_left ? provider.day_left : 0)
 					);
 				} else {
-					// Multiple providers: use new multi-provider layout
 					document.getElementById('<%=idname%>').innerHTML = progressbar_multi_<%=idname%>(save_info.providers);
 				}
 			} else {
-				// Backward compatibility: old flat format
 				document.getElementById('<%=idname%>').innerHTML = progressbar_<%=idname%>(
 					(save_info.surplus ? save_info.surplus : save_info.used),
 					(save_info.total),

--- a/luci-app-openclash/po/es/openclash.es.po
+++ b/luci-app-openclash/po/es/openclash.es.po
@@ -293,8 +293,8 @@ msgstr "Ajustes de reglas"
 msgid "Config Manage"
 msgstr "Gestión de configuraciones"
 
-msgid "Upload Config File"
-msgstr "Subir archivo de configuración"
+msgid "Add Config File"
+msgstr "Añadir archivo de configuración"
 
 msgid "Upload File Type"
 msgstr "Tipo de archivo a subir"

--- a/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
+++ b/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
@@ -293,8 +293,8 @@ msgstr "规则设置"
 msgid "Config Manage"
 msgstr "配置管理"
 
-msgid "Upload Config File"
-msgstr "上传配置文件"
+msgid "Add Config File"
+msgstr "添加配置文件"
 
 msgid "Upload File Type"
 msgstr "上传文件类型"


### PR DESCRIPTION
## 功能说明

  ### 核心功能
  **支持从配置文件读取多个订阅源并分别展示订阅信息**

  ### 主要改进

  #### 1. 订阅源读取优先级
  - 优先级1: UI手动设置的订阅URL
  - 优先级2: 配置订阅设置
  - 优先级3: **配置文件中的proxy-providers**（新增）

  #### 2. 多订阅源展示
  - **1个订阅源**：单行显示，占满宽度
  - **2个订阅源**：并排显示，各占50%
  - **3个订阅源**：并排显示，各占33%
  - **4个及以上**：横向滚动展示，每个最小33%宽度，**支持鼠标拖拽滚动**

  #### 3. 交互优化
  - 鼠标拖拽横向滚动（4个及以上订阅源时）
  - 鼠标滚轮横向滚动
  - 切换配置/刷新时显示加载状态
  - 隐藏滚动条，界面更简洁

  ### 技术更新要点

  #### 后端API改进
  - **统一返回格式**：`sub_info_get` API统一返回 `providers` 数组
  - **支持多组订阅信息**：单个订阅源也包装为数组返回，消除格式不一致
  - **支持proxy-providers**：从配置文件YAML中读取所有带订阅信息的provider

  #### 前端实现
  - **响应式布局**：Flex布局替代Grid，支持动态宽度和滚动
  - **拖拽滚动**：纯JavaScript实现，无需外部依赖
  - **状态管理**：统一处理数组格式数据，简化逻辑

  ### 使用场景示例

  **配置文件示例**
  ```yaml
  proxy-providers:
    Sub-01:
      url: "https://example.com/subscription1"
      subscription-userinfo: true

    Sub-02:
      url: "https://example.com/subscription2"
      subscription-userinfo: true

    Sub-03:
      url: "https://example.com/subscription3"
      subscription-userinfo: true

  展示效果
  - 自动读取所有订阅源信息
  - 分别显示各订阅源的流量和到期时间
  - 超过3个时可拖拽查看

  兼容性

  - ✅ 向后兼容单个订阅源
  - ✅ 无外部依赖
  - ✅ 无新增翻译文案
  - ✅ 不影响现有功能