### PR TITLE
Fix clearing luci cache.

### DIFF
--- a/luci-app-openclash/root/etc/uci-defaults/luci-openclash
+++ b/luci-app-openclash/root/etc/uci-defaults/luci-openclash
@@ -262,5 +262,6 @@ sed -i '/.*kB maximum content size*/c\export let HTTP_MAX_CONTENT = 1024*10240;	
 
 /etc/init.d/uhttpd restart >/dev/null 2>&1
 
-rm -f /tmp/luci-indexcache* >/dev/null 2>&1
+rm -f /tmp/luci-indexcache >/dev/null 2>&1
+rm -f /tmp/luci-indexcache.* >/dev/null 2>&1
 exit 0


### PR DESCRIPTION
The path to the LuCI index cache file has changed to /tmp/luci-indexcache.*.json since OpenWrt 22.03.