### PR TITLE
feat: unify subscription info tooltip format across multiple views

### DIFF
--- a/luci-app-openclash/luasrc/view/openclash/status.htm
+++ b/luci-app-openclash/luasrc/view/openclash/status.htm
@@ -3104,17 +3104,14 @@
                 (percent >= 50 ? 'high' : (percent >= 20 ? 'medium' : 'low'));
 
             var infoString = used + ' / ' + total + ' (' + percent + '%)';
+            var tooltipString = infoString;
             if (expire && expire !== 'null' && daysLeft > 0) {
-                infoString += ' • ' + '<%:Remaining%> ' + daysLeft + ' <%:days%>';
-                infoString += ' • ' + '<%:Expire Date%>: ' + expire;
+                infoString += ' • ' + expire + ' (<%:Remaining%> ' + daysLeft + ' <%:days%>)';
+                tooltipString += '\n' + expire + ' (<%:Remaining%> ' + daysLeft + ' <%:days%>)';
             }
 
             infoText.textContent = infoString;
-            if (infoText.scrollWidth > infoText.clientWidth) {
-                infoText.title = infoString;
-            } else {
-                infoText.title = '';
-            }
+            infoText.title = tooltipString;
         },
 
         displayMultipleProviders: function(providers, progressSection) {
@@ -3160,14 +3157,18 @@
                 var daysLeft = parseInt(provider.day_left, 10);
                 if (isNaN(daysLeft)) daysLeft = 0;
 
-                var infoString = providerName + ': ' + used + ' / ' + total + ' (' + percent + '%)';
+                var infoString = used + ' / ' + total + ' (' + percent + '%)';
                 if (expire && expire !== 'null' && daysLeft > 0) {
-                    infoString += ' • ' + '<%:Remaining%> ' + daysLeft + ' <%:days%>';
-                    infoString += ' • ' + '<%:Expire Date%>: ' + expire;
+                    infoString += ' • ' + expire + ' (<%:Remaining%> ' + daysLeft + ' <%:days%>)';
+                }
+
+                var tooltipString = used + ' / ' + total + ' (' + percent + '%)';
+                if (expire && expire !== 'null' && daysLeft > 0) {
+                    tooltipString += '\n' + expire + ' (<%:Remaining%> ' + daysLeft + ' <%:days%>)';
                 }
 
                 infoText.textContent = infoString;
-                infoText.title = infoString;
+                infoText.title = tooltipString;
 
                 card.appendChild(infoText);
                 progressSection.appendChild(card);

--- a/luci-app-openclash/luasrc/view/openclash/sub_info_show.htm
+++ b/luci-app-openclash/luasrc/view/openclash/sub_info_show.htm
@@ -427,18 +427,24 @@ function progressbar_<%=idname%>(v, m, pc, np, f, t, tr) {
         topPosition = tr == "null" ? '6px' : '2px';
     }
 
+    // Build title for native tooltip (format: "v / m (pc%)\nt (Remaining tr days)")
+    var titleText = v + ' / ' + m + ' (' + pc + '%%)';
+    if (t && t !== 'null' && tr && tr !== 'null' && parseInt(tr) > 0) {
+        titleText += '\n' + t + ' (<%:Remaining%> ' + tr + ' <%:days%>)';
+    }
+
     return String.format(
-        '<div class="progress_bar_bg" style="position:relative; border-radius: 6px; min-width: %s; display: flex; align-items: center;">' +
-        (pc >= 50 ? '<div class="progress_bar_high" style="width:%d%%; height:34px; border-radius: 6px">' : 
-        (pc < 50 && pc >= 20 ? '<div class="progress_bar_medium" style="width:%d%%; height:34px; border-radius: 6px">' : 
+        '<div class="progress_bar_bg" title="' + titleText + '" style="position:relative; border-radius: 6px; min-width: %s; display: flex; align-items: center;">' +
+        (pc >= 50 ? '<div class="progress_bar_high" style="width:%d%%; height:34px; border-radius: 6px">' :
+        (pc < 50 && pc >= 20 ? '<div class="progress_bar_medium" style="width:%d%%; height:34px; border-radius: 6px">' :
         '<div class="progress_bar_low" style="width:%d%%; height:34px; border-radius: 6px">')) +
         '<div style="position:absolute; left:0; top:50%%; transform: translateY(-50%%); text-align:center; width:100%%; padding:0 4px; box-sizing:border-box; line-height:1.2;">' +
-        '<small class="text_show" style="font-size:%s; line-height:1.2;">%s '+ (f ? f : '/') +' %s ' + (np ? "" : '(%s%%)') + 
-        (tr == "null" ? '<div style="visibility: hidden; line-height:1.2;">' : '<div style="visibility: visible; line-height:1.2;">') + 
+        '<small class="text_show" style="font-size:%s; line-height:1.2;">%s '+ (f ? f : '/') +' %s ' + (np ? "" : '(%s%%)') +
+        (tr == "null" ? '<div style="visibility: hidden; line-height:1.2;">' : '<div style="visibility: visible; line-height:1.2;">') +
         '%s (<%:Remaining%> %s <%:days%>)</small>' +
         '</div>' +
         '</div>' +
-        '</div>', 
+        '</div>',
         minWidth, pc, fontSize, v, m, pc, t, tr
     );
 };
@@ -473,12 +479,14 @@ function progressbar_multi_<%=idname%>(providers) {
         var expire = provider.expire || 'null';
         var dayLeft = parseInt(provider.day_left) || 0;
 
+        // Determine background color based on percentage
         var bgColorClass = percent >= 50 ? 'progress_bar_high' :
                           (percent >= 20 ? 'progress_bar_medium' : 'progress_bar_low');
 
-        var titleText = providerName + ': ' + surplus + ' / ' + total + ' (' + percent + '%)';
+        // Build title for native tooltip (format: "surplus / total (percent%)\nexpire (Remaining dayLeft days)")
+        var titleText = surplus + ' / ' + total + ' (' + percent + '%)';
         if (expire !== 'null' && dayLeft > 0) {
-            titleText += ' | ' + dayLeft + ' <%:days%>';
+            titleText += '\n' + expire + ' (<%:Remaining%> ' + dayLeft + ' <%:days%>)';
         }
 
         container += '<div class="sub_provider_item" style="width: ' + itemWidth + '" title="' + titleText + '">' +


### PR DESCRIPTION
- 统一单提供商和多提供商的tooltip信息格式
- tooltip使用两行显示：用量信息 + 过期时间信息
- 所有tooltip始终显示完整信息，不再根据溢出判断
- 页面显示使用bullet（•）连接符保持单行美观
- tooltip使用换行符（\n）实现两行清晰显示
- 保持现有DOM结构，不引入新的CSS类
- 已真机测试