### PR TITLE
fix: revert_firewall 后清除 conntrack，防止残留条目导致本地连接失败

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -3232,6 +3232,8 @@ revert_firewall()
       ipset destroy wan_ac_black_ports
       ipset destroy common_ports
    fi
+
+   conntrack -F 2>/dev/null
 } >/dev/null 2>&1
 
 add_overwrite_cron()


### PR DESCRIPTION
## 关联 Issue

Fixes #5120

## 问题

`revert_firewall()` 在删除 nftables 规则和 `@localnetwork` 集合后，没有清除 conntrack 条目。

当 watchdog 触发 `reload "firewall"` 时，`revert_firewall()` → `do_run_mode()` 之间存在竞态窗口：`@localnetwork` 集合被删除后尚未重建，此时路由器自身的 TCP 回包（如 SSH SYN-ACK）可能被兜底的 `redirect to $proxy_port` 规则错误重定向。

一旦 conntrack 记录了错误的连接状态，即使规则重建完成甚至 OpenClash 完全停止，受影响的连接也无法恢复——只有 `/etc/init.d/firewall restart`（会重置 conntrack）才能修复。

## 修复

在 `revert_firewall()` 末尾添加 `conntrack -F`，确保每次防火墙规则清理时同步清除残留的连接跟踪条目，防止旧状态污染新连接。

## 测试

- 环境：iStoreOS x86_64, fw4 (nftables), redir-host 混合模式
- 修复前：watchdog 触发 firewall reload 后 SSH 间歇性断连，需手动 `firewall restart` 恢复
- 修复后：`conntrack -F` 在 `revert_firewall` 中执行，`do_run_mode` 重建规则时不再受残留 conntrack 条目影响