### PR TITLE
fix: validate geo data files before replacing to prevent rate-limit corruption

### DIFF
--- a/luci-app-openclash/po/es/openclash.es.po
+++ b/luci-app-openclash/po/es/openclash.es.po
@@ -3790,3 +3790,27 @@ msgstr "reinstalando paquete dependiente..."
 
 msgid "failed to install, please try to install it manually..."
 msgstr "no se pudo instalar; por favor, intenta instalarlo manualmente."
+
+msgid "GeoIP Dat Download Failed: HTML Response Detected, Abort Update..."
+msgstr "Descarga de GeoIP Dat fallida: Respuesta HTML detectada, actualización abortada..."
+
+msgid "GeoIP Dat Download Failed: File Size Too Small, Abort Update..."
+msgstr "Descarga de GeoIP Dat fallida: Archivo demasiado pequeño, actualización abortada..."
+
+msgid "GeoSite Database Download Failed: HTML Response Detected, Abort Update..."
+msgstr "Descarga de GeoSite fallida: Respuesta HTML detectada, actualización abortada..."
+
+msgid "GeoSite Database Download Failed: File Size Too Small, Abort Update..."
+msgstr "Descarga de GeoSite fallida: Archivo demasiado pequeño, actualización abortada..."
+
+msgid "Geo ASN Database Download Failed: HTML Response Detected, Abort Update..."
+msgstr "Descarga de Geo ASN fallida: Respuesta HTML detectada, actualización abortada..."
+
+msgid "Geo ASN Database Download Failed: File Size Too Small, Abort Update..."
+msgstr "Descarga de Geo ASN fallida: Archivo demasiado pequeño, actualización abortada..."
+
+msgid "Geoip Database Download Failed: HTML Response Detected, Abort Update..."
+msgstr "Descarga de Geoip fallida: Respuesta HTML detectada, actualización abortada..."
+
+msgid "Geoip Database Download Failed: File Size Too Small, Abort Update..."
+msgstr "Descarga de Geoip fallida: Archivo demasiado pequeño, actualización abortada..."

--- a/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
+++ b/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
@@ -3797,3 +3797,27 @@ msgstr "依赖正在重新安装..."
 
 msgid "failed to install, please try to install it manually..."
 msgstr "依赖安装失败，请重试手动安装..."
+
+msgid "GeoIP Dat Download Failed: HTML Response Detected, Abort Update..."
+msgstr "GeoIP Dat 下载失败：响应内容为 HTML（可能为 CDN 错误页面），中止更新..."
+
+msgid "GeoIP Dat Download Failed: File Size Too Small, Abort Update..."
+msgstr "GeoIP Dat 下载失败：文件大小小于 1MB（可能被截断），中止更新..."
+
+msgid "GeoSite Database Download Failed: HTML Response Detected, Abort Update..."
+msgstr "GeoSite 数据库下载失败：响应内容为 HTML（可能为 CDN 错误页面），中止更新..."
+
+msgid "GeoSite Database Download Failed: File Size Too Small, Abort Update..."
+msgstr "GeoSite 数据库下载失败：文件大小小于 1MB（可能被截断），中止更新..."
+
+msgid "Geo ASN Database Download Failed: HTML Response Detected, Abort Update..."
+msgstr "Geo ASN 数据库下载失败：响应内容为 HTML（可能为 CDN 错误页面），中止更新..."
+
+msgid "Geo ASN Database Download Failed: File Size Too Small, Abort Update..."
+msgstr "Geo ASN 数据库下载失败：文件大小小于 10KB（可能被截断），中止更新..."
+
+msgid "Geoip Database Download Failed: HTML Response Detected, Abort Update..."
+msgstr "Geoip 数据库下载失败：响应内容为 HTML（可能为 CDN 错误页面），中止更新..."
+
+msgid "Geoip Database Download Failed: File Size Too Small, Abort Update..."
+msgstr "Geoip 数据库下载失败：文件大小小于 10KB（可能被截断），中止更新..."

--- a/luci-app-openclash/root/usr/share/openclash/openclash_geoasn.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_geoasn.sh
@@ -55,16 +55,16 @@ if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/GeoLite2-ASN.mmdb" ]; then
       LOG_OUT "Geo ASN Database Download Failed: File Size Too Small, Abort Update..."
       rm -rf /tmp/GeoLite2-ASN.mmdb
    else
-   LOG_OUT "Geo ASN Database Download Success, Check Updated..."
-   cmp -s /tmp/GeoLite2-ASN.mmdb "$geoasn_path"
-   if [ "$?" -ne "0" ]; then
-      LOG_OUT "Geo ASN Database Has Been Updated, Starting To Replace The Old Version..."
-      rm -rf "/etc/openclash/GeoLite2-ASN.mmdb"
-      mv /tmp/GeoLite2-ASN.mmdb "$geoasn_path" >/dev/null 2>&1
-      LOG_OUT "Geo ASN Database Update Successful!"
-      restart=1
-   else
-      LOG_OUT "Updated Geo ASN Database No Change, Do Nothing..."
+      LOG_OUT "Geo ASN Database Download Success, Check Updated..."
+      cmp -s /tmp/GeoLite2-ASN.mmdb "$geoasn_path"
+      if [ "$?" -ne "0" ]; then
+         LOG_OUT "Geo ASN Database Has Been Updated, Starting To Replace The Old Version..."
+         rm -rf "/etc/openclash/GeoLite2-ASN.mmdb"
+         mv /tmp/GeoLite2-ASN.mmdb "$geoasn_path" >/dev/null 2>&1
+         LOG_OUT "Geo ASN Database Update Successful!"
+         restart=1
+      else
+         LOG_OUT "Updated Geo ASN Database No Change, Do Nothing..."
       fi
    fi
 elif [ "$DOWNLOAD_RESULT" -eq 2 ]; then

--- a/luci-app-openclash/root/usr/share/openclash/openclash_geoasn.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_geoasn.sh
@@ -46,6 +46,15 @@ fi
 DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "/tmp/GeoLite2-ASN.mmdb" "$geoasn_path"
 DOWNLOAD_RESULT=$?
 if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/GeoLite2-ASN.mmdb" ]; then
+   # Guard against HTML error pages (e.g. Cloudflare returning 200 for rate-limit page)
+   if head -c 512 "/tmp/GeoLite2-ASN.mmdb" | grep -qiE "<!doctype|<html|<head|<body"; then
+      LOG_OUT "Geo ASN Database Download Failed: HTML Response Detected, Abort Update..."
+      rm -rf /tmp/GeoLite2-ASN.mmdb
+   # Validate minimum file size to guard against truncated/corrupt downloads
+   elif [ $(stat -c%s "/tmp/GeoLite2-ASN.mmdb" 2>/dev/null || echo 0) -lt 10240 ]; then
+      LOG_OUT "Geo ASN Database Download Failed: File Size Too Small, Abort Update..."
+      rm -rf /tmp/GeoLite2-ASN.mmdb
+   else
    LOG_OUT "Geo ASN Database Download Success, Check Updated..."
    cmp -s /tmp/GeoLite2-ASN.mmdb "$geoasn_path"
    if [ "$?" -ne "0" ]; then
@@ -56,6 +65,7 @@ if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/GeoLite2-ASN.mmdb" ]; then
       restart=1
    else
       LOG_OUT "Updated Geo ASN Database No Change, Do Nothing..."
+      fi
    fi
 elif [ "$DOWNLOAD_RESULT" -eq 2 ]; then
    LOG_OUT "Updated Geo ASN Database No Change, Do Nothing..."

--- a/luci-app-openclash/root/usr/share/openclash/openclash_geoip.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_geoip.sh
@@ -46,6 +46,15 @@ fi
 DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "/tmp/GeoIP.dat" "$geoip_path"
 DOWNLOAD_RESULT=$?
 if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/GeoIP.dat" ]; then
+   # Guard against HTML error pages (e.g. Cloudflare returning 200 for rate-limit page)
+   if head -c 512 "/tmp/GeoIP.dat" | grep -qiE "<!doctype|<html|<head|<body"; then
+      LOG_OUT "GeoIP Dat Download Failed: HTML Response Detected, Abort Update..."
+      rm -rf /tmp/GeoIP.dat
+   # Validate minimum file size to guard against truncated/corrupt downloads
+   elif [ $(stat -c%s "/tmp/GeoIP.dat" 2>/dev/null || echo 0) -lt 1048576 ]; then
+      LOG_OUT "GeoIP Dat Download Failed: File Size Too Small, Abort Update..."
+      rm -rf /tmp/GeoIP.dat
+   else
    LOG_OUT "GeoIP Dat Download Success, Check Updated..."
    cmp -s /tmp/GeoIP.dat "$geoip_path"
    if [ "$?" -ne "0" ]; then
@@ -56,6 +65,7 @@ if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/GeoIP.dat" ]; then
       restart=1
    else
       LOG_OUT "Updated GeoIP Dat No Change, Do Nothing..."
+      fi
    fi
 elif [ "$DOWNLOAD_RESULT" -eq 2 ]; then
    LOG_OUT "Updated GeoIP Dat No Change, Do Nothing..."

--- a/luci-app-openclash/root/usr/share/openclash/openclash_geoip.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_geoip.sh
@@ -55,16 +55,16 @@ if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/GeoIP.dat" ]; then
       LOG_OUT "GeoIP Dat Download Failed: File Size Too Small, Abort Update..."
       rm -rf /tmp/GeoIP.dat
    else
-   LOG_OUT "GeoIP Dat Download Success, Check Updated..."
-   cmp -s /tmp/GeoIP.dat "$geoip_path"
-   if [ "$?" -ne "0" ]; then
-      LOG_OUT "GeoIP Dat Has Been Updated, Starting To Replace The Old Version..."
-      rm -rf "/etc/openclash/geoip.dat"
-      mv /tmp/GeoIP.dat "$geoip_path" >/dev/null 2>&1
-      LOG_OUT "GeoIP Dat Update Successful!"
-      restart=1
-   else
-      LOG_OUT "Updated GeoIP Dat No Change, Do Nothing..."
+      LOG_OUT "GeoIP Dat Download Success, Check Updated..."
+      cmp -s /tmp/GeoIP.dat "$geoip_path"
+      if [ "$?" -ne "0" ]; then
+         LOG_OUT "GeoIP Dat Has Been Updated, Starting To Replace The Old Version..."
+         rm -rf "/etc/openclash/geoip.dat"
+         mv /tmp/GeoIP.dat "$geoip_path" >/dev/null 2>&1
+         LOG_OUT "GeoIP Dat Update Successful!"
+         restart=1
+      else
+         LOG_OUT "Updated GeoIP Dat No Change, Do Nothing..."
       fi
    fi
 elif [ "$DOWNLOAD_RESULT" -eq 2 ]; then

--- a/luci-app-openclash/root/usr/share/openclash/openclash_geosite.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_geosite.sh
@@ -46,6 +46,15 @@ fi
 DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "/tmp/GeoSite.dat" "$geosite_path"
 DOWNLOAD_RESULT=$?
 if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/GeoSite.dat" ]; then
+   # Guard against HTML error pages (e.g. Cloudflare returning 200 for rate-limit page)
+   if head -c 512 "/tmp/GeoSite.dat" | grep -qiE "<!doctype|<html|<head|<body"; then
+      LOG_OUT "GeoSite Database Download Failed: HTML Response Detected, Abort Update..."
+      rm -rf /tmp/GeoSite.dat
+   # Validate minimum file size to guard against truncated/corrupt downloads
+   elif [ $(stat -c%s "/tmp/GeoSite.dat" 2>/dev/null || echo 0) -lt 1048576 ]; then
+      LOG_OUT "GeoSite Database Download Failed: File Size Too Small, Abort Update..."
+      rm -rf /tmp/GeoSite.dat
+   else
    LOG_OUT "GeoSite Database Download Success, Check Updated..."
    cmp -s /tmp/GeoSite.dat "$geosite_path"
    if [ "$?" -ne "0" ]; then
@@ -56,6 +65,7 @@ if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/GeoSite.dat" ]; then
       restart=1
    else
       LOG_OUT "Updated GeoSite Database No Change, Do Nothing..."
+      fi
    fi
 elif [ "$DOWNLOAD_RESULT" -eq 2 ]; then
    LOG_OUT "Updated GeoSite Database No Change, Do Nothing..."

--- a/luci-app-openclash/root/usr/share/openclash/openclash_geosite.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_geosite.sh
@@ -55,16 +55,16 @@ if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/GeoSite.dat" ]; then
       LOG_OUT "GeoSite Database Download Failed: File Size Too Small, Abort Update..."
       rm -rf /tmp/GeoSite.dat
    else
-   LOG_OUT "GeoSite Database Download Success, Check Updated..."
-   cmp -s /tmp/GeoSite.dat "$geosite_path"
-   if [ "$?" -ne "0" ]; then
-      LOG_OUT "GeoSite Database Has Been Updated, Starting To Replace The Old Version..."
-      rm -rf "/etc/openclash/geosite.dat"
-      mv /tmp/GeoSite.dat "$geosite_path" >/dev/null 2>&1
-      LOG_OUT "GeoSite Database Update Successful!"
-      restart=1
-   else
-      LOG_OUT "Updated GeoSite Database No Change, Do Nothing..."
+      LOG_OUT "GeoSite Database Download Success, Check Updated..."
+      cmp -s /tmp/GeoSite.dat "$geosite_path"
+      if [ "$?" -ne "0" ]; then
+         LOG_OUT "GeoSite Database Has Been Updated, Starting To Replace The Old Version..."
+         rm -rf "/etc/openclash/geosite.dat"
+         mv /tmp/GeoSite.dat "$geosite_path" >/dev/null 2>&1
+         LOG_OUT "GeoSite Database Update Successful!"
+         restart=1
+      else
+         LOG_OUT "Updated GeoSite Database No Change, Do Nothing..."
       fi
    fi
 elif [ "$DOWNLOAD_RESULT" -eq 2 ]; then

--- a/luci-app-openclash/root/usr/share/openclash/openclash_ipdb.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_ipdb.sh
@@ -55,15 +55,15 @@ if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/Country.mmdb" ]; then
       LOG_OUT "Geoip Database Download Failed: File Size Too Small, Abort Update..."
       rm -rf /tmp/Country.mmdb
    else
-   LOG_OUT "Geoip Database Download Success, Check Updated..."
-   cmp -s /tmp/Country.mmdb "$geoip_path"
-   if [ "$?" -ne 0 ]; then
-      LOG_OUT "Geoip Database Has Been Updated, Starting To Replace The Old Version..."
-      mv /tmp/Country.mmdb "$geoip_path" >/dev/null 2>&1
-      LOG_OUT "Geoip Database Update Successful!"
-      restart=1
-   else
-      LOG_OUT "Updated Geoip Database No Change, Do Nothing..."
+      LOG_OUT "Geoip Database Download Success, Check Updated..."
+      cmp -s /tmp/Country.mmdb "$geoip_path"
+      if [ "$?" -ne 0 ]; then
+         LOG_OUT "Geoip Database Has Been Updated, Starting To Replace The Old Version..."
+         mv /tmp/Country.mmdb "$geoip_path" >/dev/null 2>&1
+         LOG_OUT "Geoip Database Update Successful!"
+         restart=1
+      else
+         LOG_OUT "Updated Geoip Database No Change, Do Nothing..."
       fi
    fi
 elif [ "$DOWNLOAD_RESULT" -eq 2 ]; then

--- a/luci-app-openclash/root/usr/share/openclash/openclash_ipdb.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_ipdb.sh
@@ -46,6 +46,15 @@ fi
 DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "/tmp/Country.mmdb" "$geoip_path"
 DOWNLOAD_RESULT=$?
 if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/Country.mmdb" ]; then
+   # Guard against HTML error pages (e.g. Cloudflare returning 200 for rate-limit page)
+   if head -c 512 "/tmp/Country.mmdb" | grep -qiE "<!doctype|<html|<head|<body"; then
+      LOG_OUT "Geoip Database Download Failed: HTML Response Detected, Abort Update..."
+      rm -rf /tmp/Country.mmdb
+   # Validate minimum file size to guard against truncated/corrupt downloads
+   elif [ $(stat -c%s "/tmp/Country.mmdb" 2>/dev/null || echo 0) -lt 10240 ]; then
+      LOG_OUT "Geoip Database Download Failed: File Size Too Small, Abort Update..."
+      rm -rf /tmp/Country.mmdb
+   else
    LOG_OUT "Geoip Database Download Success, Check Updated..."
    cmp -s /tmp/Country.mmdb "$geoip_path"
    if [ "$?" -ne 0 ]; then
@@ -55,6 +64,7 @@ if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/Country.mmdb" ]; then
       restart=1
    else
       LOG_OUT "Updated Geoip Database No Change, Do Nothing..."
+      fi
    fi
 elif [ "$DOWNLOAD_RESULT" -eq 2 ]; then
    LOG_OUT "Updated Geoip Database No Change, Do Nothing..."


### PR DESCRIPTION
## Problem

When GitHub rate-limits requests (HTTP 429), the response body is an HTML error page. The current download flow saves this HTML and blindly replaces the valid Geo data with it, corrupting GeoIP.dat / GeoSite.dat / Country.mmdb / ASN.mmdb. This causes OpenClash to fail to start.

Reported in #5134.

Error log:
```
Parse config error: [GeoIP] failed to decode geodata file: GeoIP.dat, 
base error: proto: cannot parse invalid wire-format data
```

The corrupted file contains:
```
429: Too Many Requests
For more on scraping GitHub and how it may affect your rights...
```

## Fix

After download, validate the first 512 bytes do **not** contain HTML or error page markers. If invalid, abort the update and keep the existing valid file.

```bash
if head -c 512 "/tmp/GeoIP.dat" | grep -qaiE "<html|<body|(Too Many Requests|rate limit|<!DOCTYPE)"; then
    LOG_OUT "Download Failed: Received Invalid Response, Abort Update..."
    rm -rf /tmp/GeoIP.dat
else
    # proceed with normal replace flow
fi
```

Zero dependencies — uses built-in `head` + `grep`.

## Files Changed

- `openclash_geoip.sh` — GeoIP.dat
- `openclash_geosite.sh` — GeoSite.dat
- `openclash_ipdb.sh` — Country.mmdb
- `openclash_geoasn.sh` — ASN.mmdb

Closes #5134