### PR TITLE
refactor(switch_dashboard): align buttons inline and simplify JS

### DIFF
--- a/luci-app-openclash/luasrc/view/openclash/switch_dashboard.htm
+++ b/luci-app-openclash/luasrc/view/openclash/switch_dashboard.htm
@@ -2,10 +2,10 @@
 <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 6px;">
     <div class="cbi-value-field" id="switch_dashboard_<%=self.option%>"><%:Collecting data...%></div>
     <div class="cbi-value-field" id="delete_dashboard_<%=self.option%>">
-        <input type="button" class="btn cbi-button-reset" value="<%:Delete%>" onclick="return delete_dashboard(this, '<%=self.option%>')"/>
+        <input type="button" class="btn cbi-button cbi-button-reset" value="<%:Delete%>" onclick="return delete_dashboard(this, '<%=self.option%>')"/>
     </div>
     <div class="cbi-value-field" id="default_dashboard_<%=self.option%>">
-        <input type="button" class="btn cbi-button-apply" value="<%:Set to Default%>" onclick="return default_dashboard(this, '<%=self.option%>')"/>
+        <input type="button" class="btn cbi-button cbi-button-apply" value="<%:Set to Default%>" onclick="return default_dashboard(this, '<%=self.option%>')"/>
     </div>
 </div>
 
@@ -15,7 +15,7 @@
 
     function makeBtn(label, fn, args) {
         var argStr = args.map(function(a){ return "'" + a + "'"; }).join(', ');
-        return '<input type="button" class="btn cbi-button-apply" value="' + label + '" onclick="return ' + fn + '(this, ' + argStr + ')"/>';
+        return '<input type="button" class="btn cbi-button cbi-button-apply" value="' + label + '" onclick="return ' + fn + '(this, ' + argStr + ')"/>';
     }
 
     var switchEl   = document.getElementById('switch_dashboard_'   + name);

--- a/luci-app-openclash/luasrc/view/openclash/switch_dashboard.htm
+++ b/luci-app-openclash/luasrc/view/openclash/switch_dashboard.htm
@@ -1,148 +1,110 @@
 <%+cbi/valueheader%>
-<div class="cbi-value-field" id="switch_dashboard_<%=self.option%>">
-	<%:Collecting data...%>
-</div>
-<div class="cbi-value-field" id="delete_dashboard_<%=self.option%>" style="padding-left: 5px;">
-	<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Delete%>" onclick="return delete_dashboard(this, '<%=self.option%>')"/>
-</div>
-<div class="cbi-value-field" id="default_dashboard_<%=self.option%>" style="padding-left: 5px;">
-	<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Set to Default%>" onclick="return default_dashboard(this, '<%=self.option%>')"/>
+<div style="display: flex; flex-wrap: wrap; align-items: center; gap: 6px;">
+    <div class="cbi-value-field" id="switch_dashboard_<%=self.option%>"><%:Collecting data...%></div>
+    <div class="cbi-value-field" id="delete_dashboard_<%=self.option%>">
+        <input type="button" class="btn cbi-button-reset" value="<%:Delete%>" onclick="return delete_dashboard(this, '<%=self.option%>')"/>
+    </div>
+    <div class="cbi-value-field" id="default_dashboard_<%=self.option%>">
+        <input type="button" class="btn cbi-button-apply" value="<%:Set to Default%>" onclick="return default_dashboard(this, '<%=self.option%>')"/>
+    </div>
 </div>
 
 <script type="text/javascript">//<![CDATA[
-	var btn_type_<%=self.option%> = "<%=self.option%>";
-	var switch_dashboard_<%=self.option%> = document.getElementById('switch_dashboard_<%=self.option%>');
-	var default_dashboard_<%=self.option%> = document.getElementById('default_dashboard_<%=self.option%>');
-	var delete_dashboard_<%=self.option%> = document.getElementById('delete_dashboard_<%=self.option%>');
-	XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "dashboard_type")%>', null, function(x, status) {
-      	if ( x && x.status == 200 ) {
-			if ( btn_type_<%=self.option%> == "Dashboard" ) {
-				if ( status.dashboard_type == "Meta" ) {
-					switch_dashboard_<%=self.option%>.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Switch To Official Version%>" onclick="return switch_dashboard(this, btn_type_<%=self.option%>, \'Official\')"/>';
-				}
-				else {
-					switch_dashboard_<%=self.option%>.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Switch To Meta Version%>" onclick="return switch_dashboard(this, btn_type_<%=self.option%>, \'Meta\')"/>';
-				}
-			}
-			if ( btn_type_<%=self.option%> == "Yacd" ) {
-				if ( status.yacd_type == "Meta" ) {
-					switch_dashboard_<%=self.option%>.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Switch To Official Version%>" onclick="return switch_dashboard(this, btn_type_<%=self.option%>, \'Official\')"/>';
-				}
-				else {
-					switch_dashboard_<%=self.option%>.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Switch To Meta Version%>" onclick="return switch_dashboard(this, btn_type_<%=self.option%>, \'Meta\')"/>';
-				}
-			}
-			if ( btn_type_<%=self.option%> == "Metacubexd" ) {
-				switch_dashboard_<%=self.option%>.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Update Metacubexd Version%>" onclick="return switch_dashboard(this, btn_type_<%=self.option%>, \'Official\')"/>';
-			}
-      		if ( btn_type_<%=self.option%> == "Zashboard" ) {
-				switch_dashboard_<%=self.option%>.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Update Zashboard Version%>" onclick="return switch_dashboard(this, btn_type_<%=self.option%>, \'Official\')"/>';
-			}
+(function() {
+    var name = "<%=self.option%>";
 
-			if ( status.default_dashboard == btn_type_<%=self.option%>.toLowerCase() ) {
-				default_dashboard_<%=self.option%>.innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Default%>" disabled="disabled" onclick="return default_dashboard(this, btn_type_<%=self.option%>)"/>';
-			}
+    function makeBtn(label, fn, args) {
+        var argStr = args.map(function(a){ return "'" + a + "'"; }).join(', ');
+        return '<input type="button" class="btn cbi-button-apply" value="' + label + '" onclick="return ' + fn + '(this, ' + argStr + ')"/>';
+    }
 
-			if ( !status[btn_type_<%=self.option%>.toLowerCase()] ) {
-				default_dashboard_<%=self.option%>.firstElementChild.disabled = true;
-				delete_dashboard_<%=self.option%>.firstElementChild.disabled = true;
-			}
+    var switchEl   = document.getElementById('switch_dashboard_'   + name);
+    var defaultEl  = document.getElementById('default_dashboard_'  + name);
+    var deleteEl   = document.getElementById('delete_dashboard_'   + name);
+
+    XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "dashboard_type")%>', null, function(x, status) {
+        if (!x || x.status != 200) return;
+
+        var switchLabel;
+        if (name == "Metacubexd") {
+            switchLabel = ['<%:Update Metacubexd Version%>', 'Official'];
+        } else if (name == "Zashboard") {
+            switchLabel = ['<%:Update Zashboard Version%>', 'Official'];
+        } else {
+            var isMeta = (name == "Dashboard" ? status.dashboard_type : status.yacd_type) == "Meta";
+            switchLabel = isMeta
+                ? ['<%:Switch To Official Version%>', 'Official']
+                : ['<%:Switch To Meta Version%>',    'Meta'];
         }
-	});
+        switchEl.innerHTML = makeBtn(switchLabel[0], 'switch_dashboard', [name, switchLabel[1]]);
 
-	function switch_dashboard(btn, name, type)
-	{
-		btn.disabled = true;
-		btn.value = '<%:Downloading File...%>';
-		XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "switch_dashboard")%>', {name: name, type : type}, function(x, status) {
-			if ( x && x.status == 200 ) {
-				if ( status.download_state == "0" ) {
-					if ( type == "Meta" ) {
-						if ( name == "Dashboard" ) {
-							document.getElementById("switch_dashboard_"+name).innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Switch Successful%> - <%:Switch To Official Version%>" onclick="return switch_dashboard(this, \'Dashboard\', \'Official\')"/>';
-						}
-						else
-						{
-							document.getElementById("switch_dashboard_"+name).innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Switch Successful%> - <%:Switch To Official Version%>" onclick="return switch_dashboard(this, \'Yacd\', \'Official\')"/>';
-						}
-					}
-					else {
-						if ( name == "Dashboard" ) {
-							document.getElementById("switch_dashboard_"+name).innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Switch Successful%> - <%:Switch To Meta Version%>" onclick="return switch_dashboard(this, \'Dashboard\', \'Meta\')"/>';
-						}
-						else if ( name == "Yacd" ) 
-						{
-							document.getElementById("switch_dashboard_"+name).innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Switch Successful%> - <%:Switch To Meta Version%>" onclick="return switch_dashboard(this, \'Yacd\', \'Meta\')"/>';
-						}
-						else if ( name == "Metacubexd" ) {
-							document.getElementById("switch_dashboard_"+name).innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Update Successful%> - <%:Update Metacubexd Version%>" onclick="return switch_dashboard(this, \'Metacubexd\', \'Official\')"/>';
-						} else {
-							document.getElementById("switch_dashboard_"+name).innerHTML = '<input type="button" class="btn cbi-button cbi-button-reset" value="<%:Update Successful%> - <%:Update Zashboard Version%>" onclick="return switch_dashboard(this, \'Zashboard\', \'Official\')"/>';
-            			}
-					}
-					document.getElementById("default_dashboard_"+name).firstElementChild.disabled = false;
-					document.getElementById("delete_dashboard_"+name).firstElementChild.disabled = false;
-				}
-				else if ( status.download_state == "2" ) {
-					btn.value = '<%:Unzip Error%>';
-				}
-				else {
-					if ( name == "Metacubexd" || name == "Zashboard" ) {
-						btn.value = '<%:Update Failed%>';
-					}
-					else {
-						btn.value = '<%:Switch Failed%>';
-					}
-				}
-			}
-		});
-		btn.disabled = false;
-		return false; 
-	}
+        if (status.default_dashboard == name.toLowerCase()) {
+            defaultEl.innerHTML = makeBtn('<%:Default%>', 'default_dashboard', [name]);
+            defaultEl.firstElementChild.disabled = true;
+        }
+        if (!status[name.toLowerCase()]) {
+            defaultEl.firstElementChild.disabled = true;
+            deleteEl.firstElementChild.disabled  = true;
+        }
+    });
 
-	function delete_dashboard(btn, name)
-	{
-		if ( confirm("<%:Are you sure you want to delete this panel?%>") ) {
-			btn.disabled = true;
-			XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "delete_dashboard")%>', {name: name}, function(x, status) {
-				if ( x && x.status == 200 ) {
-					if ( status.delete_state == "1" ) {
-						if ( document.getElementById('default_dashboard_' + name).firstElementChild.disabled ) {
-							document.getElementById('default_dashboard_' + name).firstElementChild.value = '<%:Set to Default%>';
-						}
-						document.getElementById('default_dashboard_' + name).firstElementChild.disabled = true;
-					}
-					else {
-						btn.disabled = false;
-					}
-				}
-			});
-		}
-		return false; 
-	}
+    window.switch_dashboard = window.switch_dashboard || function(btn, n, type) {
+        btn.disabled = true;
+        btn.value = '<%:Downloading File...%>';
+        XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "switch_dashboard")%>', {name: n, type: type}, function(x, status) {
+            if (!x || x.status != 200) return;
+            if (status.download_state == "0") {
+                var isUpdate = (n == "Metacubexd" || n == "Zashboard");
+                var nextLabel, nextType;
+                if (isUpdate) {
+                    nextLabel = '<%:Update Successful%> - ' + (n == "Metacubexd" ? '<%:Update Metacubexd Version%>' : '<%:Update Zashboard Version%>');
+                    nextType  = 'Official';
+                } else {
+                    nextLabel = '<%:Switch Successful%> - ' + (type == "Meta" ? '<%:Switch To Official Version%>' : '<%:Switch To Meta Version%>');
+                    nextType  = type == "Meta" ? 'Official' : 'Meta';
+                }
+                document.getElementById('switch_dashboard_'  + n).innerHTML = makeBtn(nextLabel, 'switch_dashboard', [n, nextType]);
+                document.getElementById('default_dashboard_' + n).firstElementChild.disabled = false;
+                document.getElementById('delete_dashboard_'  + n).firstElementChild.disabled = false;
+            } else {
+                btn.value = status.download_state == "2" ? '<%:Unzip Error%>'
+                          : (n == "Metacubexd" || n == "Zashboard") ? '<%:Update Failed%>' : '<%:Switch Failed%>';
+            }
+            btn.disabled = false;
+        });
+        return false;
+    };
 
-	function default_dashboard(btn, name)
-	{
-		btn.disabled = true;
-		XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "default_dashboard")%>', {name: name}, function(x, status) {
-			if ( x && x.status == 200 ) {
-				btn.value = '<%:Default%>';
-				btn.disabled = true;
-				var allBtns = document.querySelectorAll('[id^="default_dashboard_"]');
-				for (var i = 0; i < allBtns.length; i++) {
-					var btnEl = allBtns[i].firstElementChild;
-					if (btnEl && btnEl !== btn && btnEl.value === '<%:Default%>') {
-						btnEl.disabled = false;
-						btnEl.value = '<%:Set to Default%>';
-					}
-				}
-			} else {
-				btn.disabled = false;
-			}
-		});
-		return false; 
-	}
+    window.delete_dashboard = window.delete_dashboard || function(btn, n) {
+        if (!confirm("<%:Are you sure you want to delete this panel?%>")) return false;
+        btn.disabled = true;
+        XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "delete_dashboard")%>', {name: n}, function(x, status) {
+            if (!x || x.status != 200) { btn.disabled = false; return; }
+            if (status.delete_state == "1") {
+                var defBtn = document.getElementById('default_dashboard_' + n).firstElementChild;
+                if (defBtn.disabled) defBtn.value = '<%:Set to Default%>';
+                defBtn.disabled = true;
+            } else btn.disabled = false;
+        });
+        return false;
+    };
 
+    window.default_dashboard = window.default_dashboard || function(btn, n) {
+        btn.disabled = true;
+        XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "default_dashboard")%>', {name: n}, function(x, status) {
+            if (!x || x.status != 200) { btn.disabled = false; return; }
+            btn.value = '<%:Default%>';
+            document.querySelectorAll('[id^="default_dashboard_"]').forEach(function(el) {
+                var b = el.firstElementChild;
+                if (b && b !== btn && b.value === '<%:Default%>') {
+                    b.disabled = false;
+                    b.value = '<%:Set to Default%>';
+                }
+            });
+        });
+        return false;
+    };
+})();
 //]]></script>
 
 <%+cbi/valuefooter%>


### PR DESCRIPTION
- Wrap three cbi-value-field divs in a flex container to display buttons in one row
- Extract makeBtn() helper to reduce repeated innerHTML string building
- Wrap per-panel code in IIFE to avoid variable naming conflicts
- Register switch/delete/default functions once via window.xxx || function pattern
- Move btn.disabled = false into XHR callback for correct async behavior