### PR TITLE
fix: preserve custom template URL for subscriptions

### DIFF
--- a/luci-app-openclash/luasrc/controller/openclash.lua
+++ b/luci-app-openclash/luasrc/controller/openclash.lua
@@ -3332,6 +3332,7 @@ function action_add_subscription()
 	local sub_convert = luci.http.formvalue("sub_convert") or "0"
 	local convert_address = luci.http.formvalue("convert_address") or ""
 	local template = luci.http.formvalue("template") or ""
+	local custom_template_url = luci.http.formvalue("custom_template_url") or ""
 	local emoji = luci.http.formvalue("emoji") or "false"
 	local udp = luci.http.formvalue("udp") or "false"
 	local skip_cert_verify = luci.http.formvalue("skip_cert_verify") or "false"
@@ -3457,9 +3458,15 @@ function action_add_subscription()
 		if sub_convert == "1" then
 			uci:set("openclash", section_id, "convert_address", convert_address)
 			uci:set("openclash", section_id, "template", template)
+			if template == "0" then
+				uci:set("openclash", section_id, "custom_template_url", custom_template_url)
+			else
+				uci:delete("openclash", section_id, "custom_template_url")
+			end
 		else
 			uci:delete("openclash", section_id, "convert_address")
 			uci:delete("openclash", section_id, "template")
+			uci:delete("openclash", section_id, "custom_template_url")
 		end
 		uci:set("openclash", section_id, "emoji", emoji)
 		uci:set("openclash", section_id, "udp", udp)

--- a/luci-app-openclash/luasrc/view/openclash/config_upload.htm
+++ b/luci-app-openclash/luasrc/view/openclash/config_upload.htm
@@ -1243,7 +1243,7 @@ var ConfigUploader = {
             }
         }
 
-        if (data.sub_convert === '1' || data.convert_address || data.template || data.emoji === 'true' || data.udp === 'true' || data.skip_cert_verify === 'true' || data.sort === 'true' || data.node_type === 'true' || data.rule_provider === 'true' || data.custom_params || data.keyword || data.ex_keyword || data.de_ex_keyword) {
+        if (data.sub_convert === '1' || data.convert_address || data.template || data.custom_template_url || data.emoji === 'true' || data.udp === 'true' || data.skip_cert_verify === 'true' || data.sort === 'true' || data.node_type === 'true' || data.rule_provider === 'true' || data.custom_params || data.keyword || data.ex_keyword || data.de_ex_keyword) {
             document.getElementById('advanced-options-enable').checked = true;
             document.getElementById('advanced-options-container').style.display = 'block';
 
@@ -1282,7 +1282,7 @@ var ConfigUploader = {
                     } else if (data.template === '0') {
                         templateSelect.value = '0';
                         document.getElementById('custom-template-group').style.display = 'block';
-                        document.getElementById('custom-template-input').value = data.custom_template || '';
+                        document.getElementById('custom-template-input').value = data.custom_template_url || data.custom_template || '';
                     }
                 }
 
@@ -1535,6 +1535,7 @@ var ConfigUploader = {
         var sort = false;
         var nodeType = false;
         var ruleProvider = false;
+        var customTemplateUrl = '';
         var customParams = '';
         var keywords = '';
         var excludeKeywords = '';
@@ -1565,7 +1566,7 @@ var ConfigUploader = {
             }
 
             if (template === '0') {
-                template = customTemplate.trim();
+                customTemplateUrl = customTemplate.trim();
             }
         }
 
@@ -1640,6 +1641,7 @@ var ConfigUploader = {
             sub_convert: subConvert ? '1' : '0',
             convert_address: convertAddress,
             template: template,
+            custom_template_url: customTemplateUrl,
             emoji: emoji ? 'true' : 'false',
             udp: udp ? 'true' : 'false',
             skip_cert_verify: skipCert ? 'true' : 'false',


### PR DESCRIPTION
Fixes #5156 

# 问题说明

新版“配置管理 / 上传配置”弹窗中，启用“在线订阅转换”并选择“自定义模板”后，自定义模板 URL 没有按后端约定保存到 `custom_template_url`，而是被写入了 `template`。

现有后端脚本 `openclash.sh` 已经按以下方式处理模板参数：

```text
内置模板：template='模板名'
自定义模板：template='0' + custom_template_url='<custom ini url>'
```

因此当前前端和 controller 的保存结果会导致自定义模板分支无法正确生效，更新配置时可能无法拼接正确的订阅转换参数，并退回直接下载订阅地址。

<img width="1340" height="894" alt="image" src="https://github.com/user-attachments/assets/cea86b29-2115-4502-9df7-626a737f8f73" />


## 修改内容

- 前端选择“自定义模板”时，保持 `template` 为 `0`。
- 前端新增提交 `custom_template_url`，用于传递自定义模板 URL。
- 编辑已有订阅配置时，从 `custom_template_url` 回填自定义模板输入框。
- controller 的 `action_add_subscription()` 新增读取并保存 `custom_template_url`。
- 当选择内置模板或关闭“在线订阅转换”时，删除旧的 `custom_template_url`，避免残留配置。
- `openclash.sh` 已有对应处理逻辑，本次无需修改。

- [x] `git diff --check` 通过。
- [x] 已在本地路由器环境替换 LuCI 文件测试页面可加载。
- [x] 已在路由器上执行 controller Lua 语法检查。

<img width="771" height="1269" alt="image" src="https://github.com/user-attachments/assets/dcd6b1ab-429a-48f5-9a88-cc1c91fe18ca" />

<img width="1329" height="645" alt="image" src="https://github.com/user-attachments/assets/e5180cc8-8e39-441e-8034-4fe53da42b80" />
