### PR TITLE
Fixed download timeout issues

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh
@@ -27,7 +27,7 @@ DOWNLOAD_FILE_CURL() {
         LOG_OUT "Downloading:【$(basename "$DOWNLOAD_PATH") - 0%】"
 
         (
-            curl -# -L --connect-timeout 10 -m 60 --speed-time 20 --speed-limit 1 --retry 2 \
+            curl -# -L --connect-timeout 10 --speed-time 20 --speed-limit 1 --retry 2 \
                 -H "User-Agent: ${DOWNLOAD_UA}" \
                 "$DOWNLOAD_URL" -o "$DOWNLOAD_PATH" 2>"$TEMP_LOG"
             echo $? > "${TEMP_LOG}.exit"
@@ -73,7 +73,7 @@ DOWNLOAD_FILE_CURL() {
             return 1
         fi
     else
-        CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 60 --speed-time 30 --speed-limit 1 --retry 2 -H "User-Agent: ${DOWNLOAD_UA}" "$DOWNLOAD_URL" -o "$DOWNLOAD_PATH" 2>&1)
+        CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 --speed-time 30 --speed-limit 1 --retry 2 -H "User-Agent: ${DOWNLOAD_UA}" "$DOWNLOAD_URL" -o "$DOWNLOAD_PATH" 2>&1)
         EXIR_CODE=$?
         HTTP_CODE=$(echo "$CURL_OUTPUT" | tail -n1)
 


### PR DESCRIPTION
相关issue: https://github.com/vernesong/OpenClash/issues/5107

如果直连下载网络过慢，会一直反复下载失败，日志如下：
```
2026-06-02 01:14:15 [信息] 【/tmp/clash_meta.tar.gz】下载失败：【curl: (28) Operation timed out after 60000 milliseconds with 4433046 out of 12392718 bytes received】
2026-06-02 01:14:15 [信息] 下载进度：【clash_meta.tar.gz - 35%】
2026-06-02 01:14:14 [信息] 下载进度：【clash_meta.tar.gz - 34%】
2026-06-02 01:14:13 [信息] 下载进度：【clash_meta.tar.gz - 33%】
2026-06-02 01:14:12 [信息] 下载进度：【clash_meta.tar.gz - 32%】
2026-06-02 01:14:11 [信息] 下载进度：【clash_meta.tar.gz - 31%】
2026-06-02 01:14:10 [信息] 下载进度：【clash_meta.tar.gz - 30%】
2026-06-02 01:14:06 [信息] 下载进度：【clash_meta.tar.gz - 29%】
2026-06-02 01:14:04 [信息] 下载进度：【clash_meta.tar.gz - 28%】
2026-06-02 01:14:02 [信息] 下载进度：【clash_meta.tar.gz - 27%】
2026-06-02 01:14:00 [信息] 下载进度：【clash_meta.tar.gz - 26%】
2026-06-02 01:13:59 [信息] 下载进度：【clash_meta.tar.gz - 25%】
2026-06-02 01:13:57 [信息] 下载进度：【clash_meta.tar.gz - 24%】
2026-06-02 01:13:56 [信息] 下载进度：【clash_meta.tar.gz - 23%】
2026-06-02 01:13:55 [信息] 下载进度：【clash_meta.tar.gz - 22%】
2026-06-02 01:13:53 [信息] 下载进度：【clash_meta.tar.gz - 21%】
2026-06-02 01:13:52 [信息] 下载进度：【clash_meta.tar.gz - 20%】
2026-06-02 01:13:50 [信息] 下载进度：【clash_meta.tar.gz - 19%】
2026-06-02 01:13:49 [信息] 下载进度：【clash_meta.tar.gz - 18%】
2026-06-02 01:13:47 [信息] 下载进度：【clash_meta.tar.gz - 17%】
2026-06-02 01:13:46 [信息] 下载进度：【clash_meta.tar.gz - 16%】
2026-06-02 01:13:44 [信息] 下载进度：【clash_meta.tar.gz - 15%】
2026-06-02 01:13:42 [信息] 下载进度：【clash_meta.tar.gz - 14%】
2026-06-02 01:13:41 [信息] 下载进度：【clash_meta.tar.gz - 13%】
2026-06-02 01:13:40 [信息] 下载进度：【clash_meta.tar.gz - 12%】
2026-06-02 01:13:39 [信息] 下载进度：【clash_meta.tar.gz - 10%】
2026-06-02 01:13:38 [信息] 下载进度：【clash_meta.tar.gz - 6%】
2026-06-02 01:13:37 [信息] 下载进度：【clash_meta.tar.gz - 0%】
2026-06-02 01:13:37 [提示] 【Meta】版本内核正在下载，如下载失败请尝试手动下载并上传...
2026-06-02 01:13:36 [错误] 【OpenClash - v0.47.097】下载失败，请检查网络或稍后再试！
2026-06-02 01:13:36 [信息] 【/tmp/openclash.apk】下载失败：【curl: (28) Operation timed out after 60007 milliseconds with 2069388 out of 7314904 bytes received】
2026-06-02 01:13:24 [提示] OpenClash 已关闭！
2026-06-02 01:13:24 [信息] 第五步：删除 OpenClash 残留文件...
2026-06-02 01:13:17 [信息] 第四步: 重启 Dnsmasq 程序...
2026-06-02 01:13:17 [信息] 第三步: 关闭 OpenClash 相关服务...
2026-06-02 01:13:17 [信息] 第二步: 删除 OpenClash 防火墙规则...
2026-06-02 01:13:17 [信息] 第一步: 备份当前策略组状态...
2026-06-02 01:13:17 [提示] OpenClash 开始关闭...
2026-06-02 01:14:15 [错误] 【2/3】【Meta】版本内核下载失败...
2026-06-02 01:14:15 [信息] 【/tmp/clash_meta.tar.gz】下载失败：【curl: (28) Operation timed out after 60000 milliseconds with 4433046 out of 12392718 bytes received】
2026-06-02 01:14:15 [信息] 下载进度：【clash_meta.tar.gz - 35%】
2026-06-02 01:14:14 [信息] 下载进度：【clash_meta.tar.gz - 34%】
2026-06-02 01:14:13 [信息] 下载进度：【clash_meta.tar.gz - 33%】
2026-06-02 01:14:12 [信息] 下载进度：【clash_meta.tar.gz - 32%】
2026-06-02 01:14:11 [信息] 下载进度：【clash_meta.tar.gz - 31%】
2026-06-02 01:14:10 [信息] 下载进度：【clash_meta.tar.gz - 30%】
2026-06-02 01:14:06 [信息] 下载进度：【clash_meta.tar.gz - 29%】
2026-06-02 01:14:04 [信息] 下载进度：【clash_meta.tar.gz - 28%】
2026-06-02 01:14:02 [信息] 下载进度：【clash_meta.tar.gz - 27%】
2026-06-02 01:14:00 [信息] 下载进度：【clash_meta.tar.gz - 26%】
2026-06-02 01:13:59 [信息] 下载进度：【clash_meta.tar.gz - 25%】
2026-06-02 01:13:57 [信息] 下载进度：【clash_meta.tar.gz - 24%】
2026-06-02 01:13:56 [信息] 下载进度：【clash_meta.tar.gz - 23%】
2026-06-02 01:13:55 [信息] 下载进度：【clash_meta.tar.gz - 22%】
2026-06-02 01:13:53 [信息] 下载进度：【clash_meta.tar.gz - 21%】
2026-06-02 01:13:52 [信息] 下载进度：【clash_meta.tar.gz - 20%】
2026-06-02 01:13:50 [信息] 下载进度：【clash_meta.tar.gz - 19%】
2026-06-02 01:13:49 [信息] 下载进度：【clash_meta.tar.gz - 18%】
2026-06-02 01:13:47 [信息] 下载进度：【clash_meta.tar.gz - 17%】
2026-06-02 01:13:46 [信息] 下载进度：【clash_meta.tar.gz - 16%】
2026-06-02 01:13:44 [信息] 下载进度：【clash_meta.tar.gz - 15%】
2026-06-02 01:13:42 [信息] 下载进度：【clash_meta.tar.gz - 14%】
2026-06-02 01:13:41 [信息] 下载进度：【clash_meta.tar.gz - 13%】
2026-06-02 01:13:40 [信息] 下载进度：【clash_meta.tar.gz - 12%】
2026-06-02 01:13:39 [信息] 下载进度：【clash_meta.tar.gz - 10%】
2026-06-02 01:13:38 [信息] 下载进度：【clash_meta.tar.gz - 6%】
2026-06-02 01:13:37 [信息] 下载进度：【clash_meta.tar.gz - 0%】
2026-06-02 01:13:37 [提示] 【Meta】版本内核正在下载，如下载失败请尝试手动下载并上传...
2026-06-02 01:13:36 [错误] 【OpenClash - v0.47.097】下载失败，请检查网络或稍后再试！
2026-06-02 01:13:36 [信息] 【/tmp/openclash.apk】下载失败：【curl: (28) Operation timed out after 60007 milliseconds with 2069388 out of 7314904 bytes received】
```