### PR TITLE
fix OIX download TLS failures

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/clash_version.sh
+++ b/luci-app-openclash/root/usr/share/openclash/clash_version.sh
@@ -25,7 +25,12 @@ if [ -n "$1" ]; then
 fi
 
 if [ "$CORE_TYPE" = "Oix" ] || [ -n "$OIX_TOKEN" ]; then
-   DOWNLOAD_URL="https://dl.dler.io/mihomo-oix/version.txt?tag=Pre-Alpha"
+   OIX_VERSION_URL="https://github.com/vernesong/mihomo-oix/releases/download/Pre-Alpha/version.txt"
+   if [ "$github_address_mod" != "0" ] && [ "$github_address_mod" != "https://cdn.jsdelivr.net/" ] && [ "$github_address_mod" != "https://fastly.jsdelivr.net/" ] && [ "$github_address_mod" != "https://testingcf.jsdelivr.net/" ]; then
+      DOWNLOAD_URL="${github_address_mod}${OIX_VERSION_URL}"
+   else
+      DOWNLOAD_URL="$OIX_VERSION_URL"
+   fi
 else
    if [ "$github_address_mod" != "0" ]; then
       if [ "$github_address_mod" == "https://cdn.jsdelivr.net/" ] || [ "$github_address_mod" == "https://fastly.jsdelivr.net/" ] || [ "$github_address_mod" == "https://testingcf.jsdelivr.net/" ]; then

--- a/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
@@ -87,7 +87,12 @@ if [ "$CORE_CV" != "$CORE_LV" ] || [ -z "$CORE_CV" ]; then
    if [ "$CPU_MODEL" != 0 ]; then
       LOG_TIP "【$CORE_TYPE】Core Downloading, Please Try to Download and Upload Manually If Fails"
       if [ "$CORE_TYPE" = "Oix" ]; then
-         DOWNLOAD_URL="https://dl.dler.io/mihomo-oix/mihomo-${CPU_MODEL}-${CORE_LV}.gz?tag=Pre-Alpha"
+         OIX_CORE_URL="https://github.com/vernesong/mihomo-oix/releases/download/Pre-Alpha/mihomo-${CPU_MODEL}-${CORE_LV}.gz"
+         if [ "$github_address_mod" != "0" ] && [ "$github_address_mod" != "https://cdn.jsdelivr.net/" ] && [ "$github_address_mod" != "https://fastly.jsdelivr.net/" ] && [ "$github_address_mod" != "https://testingcf.jsdelivr.net/" ]; then
+            DOWNLOAD_URL="${github_address_mod}${OIX_CORE_URL}"
+         else
+            DOWNLOAD_URL="$OIX_CORE_URL"
+         fi
       else
          if [ "$github_address_mod" != "0" ]; then
             if [ "$github_address_mod" == "https://cdn.jsdelivr.net/" ] || [ "$github_address_mod" == "https://fastly.jsdelivr.net/" ] || [ "$github_address_mod" == "https://testingcf.jsdelivr.net/" ]; then

--- a/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh
@@ -10,28 +10,20 @@ DOWNLOAD_FILE_CURL() {
     DOWNLOAD_UA=$4
     SECRET_KEY=$5
     [ -z "$DOWNLOAD_UA" ] && DOWNLOAD_UA="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
-
-    if [ -n "$SECRET_KEY" ]; then
-        CURL_OUTPUT=$(curl -sLI --connect-timeout 5 -m 10 --speed-time 5 --speed-limit 1 --retry 2 \
-            -H "User-Agent: ${DOWNLOAD_UA}" \
-            -H "X-Age-Public-Key: ${SECRET_KEY}" \
-            "$DOWNLOAD_URL" 2>&1)
-    else
-        CURL_OUTPUT=$(curl -sLI --connect-timeout 5 -m 10 --speed-time 5 --speed-limit 1 --retry 2 \
-            -H "User-Agent: ${DOWNLOAD_UA}" "$DOWNLOAD_URL" 2>&1)
-    fi
-
-    NEW_ETAG=$(echo "$CURL_OUTPUT" | grep -i "^etag:" | cut -d' ' -f2- | tr -d '\r\n' | sed 's/^"//;s/"$//')
-    HTTP_CODE=$(echo "$CURL_OUTPUT" | grep -i "^HTTP" | tail -1 | cut -d' ' -f2)
+    HEADER_TMP="/tmp/openclash_curl_header_$$"
+    DOWNLOAD_TMP="${DOWNLOAD_PATH}.download.$$"
     CACHED_ETAG=$(GET_ETAG_BY_PATH "$FILE_PATH")
+    ETAG_HEADER=""
 
-    if [ "$HTTP_CODE" = "200" ] && [ -n "$NEW_ETAG" ] && [ "$NEW_ETAG" = "$CACHED_ETAG" ] && [ -e "$FILE_PATH" ]; then
+    if [ -n "$CACHED_ETAG" ] && [ -e "$FILE_PATH" ]; then
         FILE_MTIME=$(date -r "$FILE_PATH" '+%Y-%m-%d %H:%M:%S' 2>/dev/null)
         LAST_UPDATE=$(GET_ETAG_TIMESTAMP_BY_PATH "$FILE_PATH")
         if [ -n "$LAST_UPDATE" ] && [ -n "$FILE_MTIME" ] && [ "$LAST_UPDATE" = "$FILE_MTIME" ]; then
-            return 2
+            ETAG_HEADER="If-None-Match: \"${CACHED_ETAG}\""
         fi
     fi
+
+    rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
 
     if [ "$SHOW_DOWNLOAD_PROGRESS" = "1" ] || [ "$SHOW_DOWNLOAD_PROGRESS" = "true" ]; then
         TEMP_LOG="/tmp/curl_log_$$"
@@ -39,15 +31,30 @@ DOWNLOAD_FILE_CURL() {
         LOG_OUT "Downloading:【$(basename "$DOWNLOAD_PATH") - 0%】"
 
         (
-            if [ -n "$SECRET_KEY" ]; then
+            if [ -n "$SECRET_KEY" ] && [ -n "$ETAG_HEADER" ]; then
                 curl -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                    -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
                     -H "X-Age-Public-Key: ${SECRET_KEY}" \
-                    "$DOWNLOAD_URL" -o "$DOWNLOAD_PATH" 2>"$TEMP_LOG"
+                    -H "$ETAG_HEADER" \
+                    "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>"$TEMP_LOG"
+            elif [ -n "$SECRET_KEY" ]; then
+                curl -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                    -D "$HEADER_TMP" \
+                    -H "User-Agent: ${DOWNLOAD_UA}" \
+                    -H "X-Age-Public-Key: ${SECRET_KEY}" \
+                    "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>"$TEMP_LOG"
+            elif [ -n "$ETAG_HEADER" ]; then
+                curl -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                    -D "$HEADER_TMP" \
+                    -H "User-Agent: ${DOWNLOAD_UA}" \
+                    -H "$ETAG_HEADER" \
+                    "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>"$TEMP_LOG"
             else
                 curl -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                    -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
-                    "$DOWNLOAD_URL" -o "$DOWNLOAD_PATH" 2>"$TEMP_LOG"
+                    "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>"$TEMP_LOG"
             fi
             echo $? > "${TEMP_LOG}.exit"
         ) &
@@ -74,6 +81,7 @@ DOWNLOAD_FILE_CURL() {
 
         wait $CURL_PID
         EXIR_CODE=$(cat "${TEMP_LOG}.exit" 2>/dev/null || echo "1")
+        HTTP_CODE=$(grep -i "^HTTP" "$HEADER_TMP" 2>/dev/null | tail -1 | cut -d' ' -f2)
 
         if [ "$EXIR_CODE" -eq 0 ] && [ "$LAST_PROGRESS" -ne 100 ]; then
             LOG_OUT "Downloading:【$(basename "$DOWNLOAD_PATH") - 100%】"
@@ -85,36 +93,82 @@ DOWNLOAD_FILE_CURL() {
 
         rm -f "$TEMP_LOG" "${TEMP_LOG}.exit"
 
-        if [ "$EXIR_CODE" -ne 0 ]; then
+        if [ "$EXIR_CODE" -eq 0 ] && [ "$HTTP_CODE" = "304" ] && [ -e "$FILE_PATH" ]; then
+            rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
+            return 2
+        fi
+
+        if [ "$EXIR_CODE" -ne 0 ] || [ "$HTTP_CODE" != "200" ]; then
             LOG_OUT "【$DOWNLOAD_PATH】Download Failed:【$OUTPUT】"
-            rm -rf "$DOWNLOAD_PATH"
+            rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
             SLOG_CLEAN
             return 1
         fi
     else
-        if [ -n "$SECRET_KEY" ]; then
-            CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
-                -H "User-Agent: ${DOWNLOAD_UA}" \
-                -H "X-Age-Public-Key: ${SECRET_KEY}" \
-                "$DOWNLOAD_URL" -o "$DOWNLOAD_PATH" 2>&1)
-        else
-            CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 -H "User-Agent: ${DOWNLOAD_UA}" "$DOWNLOAD_URL" -o "$DOWNLOAD_PATH" 2>&1)
-        fi
-        EXIR_CODE=$?
-        HTTP_CODE=$(echo "$CURL_OUTPUT" | tail -n1)
+        DOWNLOAD_TRY=0
+        MAX_DOWNLOAD_RETRIES=3
+        while [ "$DOWNLOAD_TRY" -lt "$MAX_DOWNLOAD_RETRIES" ]; do
+            DOWNLOAD_TRY=$((DOWNLOAD_TRY + 1))
+            rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
+            if [ -n "$SECRET_KEY" ] && [ -n "$ETAG_HEADER" ]; then
+                CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                    -D "$HEADER_TMP" \
+                    -H "User-Agent: ${DOWNLOAD_UA}" \
+                    -H "X-Age-Public-Key: ${SECRET_KEY}" \
+                    -H "$ETAG_HEADER" \
+                    "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>&1)
+            elif [ -n "$SECRET_KEY" ]; then
+                CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                    -D "$HEADER_TMP" \
+                    -H "User-Agent: ${DOWNLOAD_UA}" \
+                    -H "X-Age-Public-Key: ${SECRET_KEY}" \
+                    "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>&1)
+            elif [ -n "$ETAG_HEADER" ]; then
+                CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                    -D "$HEADER_TMP" \
+                    -H "User-Agent: ${DOWNLOAD_UA}" \
+                    -H "$ETAG_HEADER" \
+                    "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>&1)
+            else
+                CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                    -D "$HEADER_TMP" \
+                    -H "User-Agent: ${DOWNLOAD_UA}" "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>&1)
+            fi
+            EXIR_CODE=$?
+            HTTP_CODE=$(echo "$CURL_OUTPUT" | tail -n1)
+            if { [ "$EXIR_CODE" -eq 0 ] && [ "$HTTP_CODE" = "200" ]; } || { [ "$EXIR_CODE" -eq 0 ] && [ "$HTTP_CODE" = "304" ] && [ -e "$FILE_PATH" ]; }; then
+                break
+            fi
+            [ "$DOWNLOAD_TRY" -lt "$MAX_DOWNLOAD_RETRIES" ] && sleep 1
+        done
 
-        if [ "$EXIR_CODE" -ne 0 ] || [ "$HTTP_CODE" -ne 200 ]; then
+        if [ "$EXIR_CODE" -eq 0 ] && [ "$HTTP_CODE" = "304" ] && [ -e "$FILE_PATH" ]; then
+            rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
+            return 2
+        fi
+
+        if [ "$EXIR_CODE" -ne 0 ] || [ "$HTTP_CODE" != "200" ]; then
             OUTPUT=$(echo "$CURL_OUTPUT" | sed '$d' | grep -a 'curl:' | tail -n 1)
             LOG_OUT "【$DOWNLOAD_PATH】Download Failed:【$OUTPUT】"
-            rm -rf "$DOWNLOAD_PATH"
+            rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
             SLOG_CLEAN
             return 1
         fi
     fi
 
+    if ! mv -f "$DOWNLOAD_TMP" "$DOWNLOAD_PATH"; then
+        LOG_OUT "【$DOWNLOAD_PATH】Download Failed:【Unable to save download file】"
+        rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
+        SLOG_CLEAN
+        return 1
+    fi
+    NEW_ETAG=$(grep -i "^etag:" "$HEADER_TMP" 2>/dev/null | tail -1 | cut -d' ' -f2- | tr -d '\r\n' | sed 's/^"//;s/"$//')
+
     if [ -n "$NEW_ETAG" ] && [ "$HTTP_CODE" = "200" ]; then
         SAVE_ETAG_TO_CACHE "$DOWNLOAD_URL" "$NEW_ETAG" "$FILE_PATH"
     fi
+
+    rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
 
     return 0
 }

--- a/tests/oix_release_url_test.sh
+++ b/tests/oix_release_url_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLASH_VERSION="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/clash_version.sh"
+OPENCLASH_CORE="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_core.sh"
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'Expected %s to contain: %s\n' "$file" "$expected" >&2
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq -- "$unexpected" "$file"; then
+    printf 'Expected %s not to contain: %s\n' "$file" "$unexpected" >&2
+    return 1
+  fi
+}
+
+assert_contains "$CLASH_VERSION" "github.com/vernesong/mihomo-oix/releases/download/Pre-Alpha/version.txt"
+assert_contains "$OPENCLASH_CORE" "github.com/vernesong/mihomo-oix/releases/download/Pre-Alpha/mihomo-\${CPU_MODEL}-\${CORE_LV}.gz"
+assert_not_contains "$CLASH_VERSION" "dl.dler.io/mihomo-oix"
+assert_not_contains "$OPENCLASH_CORE" "dl.dler.io/mihomo-oix"
+
+printf 'oix release URL tests passed\n'

--- a/tests/openclash_curl_test.sh
+++ b/tests/openclash_curl_test.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+SCRIPT_UNDER_TEST="$TMP_DIR/openclash_curl.sh"
+STUB_DIR="$TMP_DIR/stubs"
+BIN_DIR="$TMP_DIR/bin"
+mkdir -p "$STUB_DIR" "$BIN_DIR"
+
+awk -v stub_dir="$STUB_DIR" '
+  $0 == ". /usr/share/openclash/log.sh" {
+    print ". \"" stub_dir "/log.sh\""
+    next
+  }
+  $0 == ". /usr/share/openclash/openclash_etag.sh" {
+    print ". \"" stub_dir "/openclash_etag.sh\""
+    next
+  }
+  { print }
+' "$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh" > "$SCRIPT_UNDER_TEST"
+
+cat > "$STUB_DIR/log.sh" <<'STUB'
+LOG_OUT() { printf '%s\n' "$1" >> "$TEST_LOG"; }
+SLOG_CLEAN() { :; }
+STUB
+
+cat > "$STUB_DIR/openclash_etag.sh" <<'STUB'
+GET_ETAG_BY_PATH() {
+  [ -n "${TEST_CACHED_ETAG:-}" ] && printf '%s\n' "$TEST_CACHED_ETAG"
+}
+
+GET_ETAG_TIMESTAMP_BY_PATH() {
+  [ -n "${TEST_CACHED_TIME:-}" ] && printf '%s\n' "$TEST_CACHED_TIME"
+}
+
+SAVE_ETAG_TO_CACHE() {
+  printf '%s|%s|%s\n' "$1" "$2" "$3" >> "$TEST_ETAG_SAVE_LOG"
+}
+STUB
+
+cat > "$BIN_DIR/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$TEST_CURL_CALLS"
+
+is_head=0
+header_file=""
+output_file=""
+write_http=0
+if_none_match=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -*I*)
+      is_head=1
+      ;;
+    -D)
+      shift
+      header_file="$1"
+      ;;
+    -o)
+      shift
+      output_file="$1"
+      ;;
+    -w)
+      shift
+      write_http=1
+      ;;
+    -H)
+      shift
+      case "$1" in
+        If-None-Match:*) if_none_match=1 ;;
+      esac
+      ;;
+  esac
+  shift || true
+done
+
+if [ "$is_head" -eq 1 ]; then
+  touch "$TEST_HEAD_SEEN"
+  printf 'HTTP/2 200\r\netag: "etag-new"\r\ncontent-length: 7\r\n\r\n'
+  exit 0
+fi
+
+if [ -f "$TEST_HEAD_SEEN" ]; then
+  printf 'curl: (35) TLS connect error: error:00000000:lib(0)::reason(0)\n' >&2
+  [ "$write_http" -eq 1 ] && printf '\n000'
+  exit 35
+fi
+
+if [ "${TEST_FAIL_FIRST_GET:-0}" = "1" ] && [ ! -f "$TEST_FIRST_GET_FAILED" ]; then
+  touch "$TEST_FIRST_GET_FAILED"
+  printf 'curl: (35) TLS connect error: error:00000000:lib(0)::reason(0)\n' >&2
+  [ "$write_http" -eq 1 ] && printf '\n000'
+  exit 35
+fi
+
+if [ "$if_none_match" -eq 1 ]; then
+  [ -n "$header_file" ] && printf 'HTTP/2 304\r\netag: "etag-old"\r\n\r\n' > "$header_file"
+  [ "$write_http" -eq 1 ] && printf '\n304'
+  exit 0
+fi
+
+[ -n "$header_file" ] && printf 'HTTP/2 200\r\netag: "etag-new"\r\ncontent-length: 7\r\n\r\n' > "$header_file"
+[ -n "$output_file" ] && printf 'payload' > "$output_file"
+[ "$write_http" -eq 1 ] && printf '\n200'
+exit 0
+STUB
+chmod +x "$BIN_DIR/curl"
+
+cat > "$BIN_DIR/date" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-r" ]; then
+  printf '%s\n' "${TEST_FILE_MTIME:-2026-01-01 00:00:00}"
+else
+  /bin/date "$@"
+fi
+STUB
+chmod +x "$BIN_DIR/date"
+
+run_case() {
+  local name="$1"
+  shift
+  local case_dir="$TMP_DIR/$name"
+  mkdir -p "$case_dir"
+  export TEST_LOG="$case_dir/log"
+  export TEST_CURL_CALLS="$case_dir/curl_calls"
+  export TEST_ETAG_SAVE_LOG="$case_dir/etag_save"
+  export TEST_HEAD_SEEN="$case_dir/head_seen"
+  export TEST_FIRST_GET_FAILED="$case_dir/first_get_failed"
+  export PATH="$BIN_DIR:$PATH"
+  : > "$TEST_LOG"
+  : > "$TEST_CURL_CALLS"
+  : > "$TEST_ETAG_SAVE_LOG"
+  rm -f "$TEST_HEAD_SEEN"
+  rm -f "$TEST_FIRST_GET_FAILED"
+  "$@"
+}
+
+assert_file_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'Expected %s to contain: %s\n' "$file" "$expected" >&2
+    printf 'Actual:\n' >&2
+    cat "$file" >&2
+    return 1
+  fi
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    printf '%s: expected %s, got %s\n' "$message" "$expected" "$actual" >&2
+    return 1
+  fi
+}
+
+assert_file_missing() {
+  local file="$1"
+  if [ -e "$file" ]; then
+    printf 'Expected %s to be absent\n' "$file" >&2
+    return 1
+  fi
+}
+
+test_download_uses_single_get_with_headers() {
+  local output="$TMP_DIR/downloaded"
+  rm -f "$output"
+  unset TEST_CACHED_ETAG TEST_CACHED_TIME
+  # shellcheck disable=SC1090
+  . "$SCRIPT_UNDER_TEST"
+
+  set +e
+  DOWNLOAD_FILE_CURL "https://example.com/file" "$output" "$output"
+  local rc=$?
+  set -e
+
+  assert_eq "$rc" "0" "download rc"
+  assert_eq "$(cat "$output" 2>/dev/null)" "payload" "downloaded payload"
+  assert_eq "$(wc -l < "$TEST_CURL_CALLS" | tr -d ' ')" "1" "curl call count"
+  if grep -Eq '(^| )-[^ ]*I' "$TEST_CURL_CALLS"; then
+    printf 'DOWNLOAD_FILE_CURL must not issue a separate HEAD request\n' >&2
+    cat "$TEST_CURL_CALLS" >&2
+    return 1
+  fi
+  assert_file_contains "$TEST_CURL_CALLS" "-D"
+  assert_file_contains "$TEST_ETAG_SAVE_LOG" "https://example.com/file|etag-new|$output"
+}
+
+test_conditional_get_returns_not_modified() {
+  local output="$TMP_DIR/cached"
+  printf 'cached' > "$output"
+  export TEST_CACHED_ETAG="etag-old"
+  export TEST_CACHED_TIME="2026-01-01 00:00:00"
+  export TEST_FILE_MTIME="2026-01-01 00:00:00"
+  # shellcheck disable=SC1090
+  . "$SCRIPT_UNDER_TEST"
+
+  set +e
+  DOWNLOAD_FILE_CURL "https://example.com/file" "$output.tmp" "$output"
+  local rc=$?
+  set -e
+
+  assert_eq "$rc" "2" "not modified rc"
+  assert_eq "$(cat "$output")" "cached" "cached payload"
+  assert_file_missing "$output.tmp"
+  assert_eq "$(wc -l < "$TEST_CURL_CALLS" | tr -d ' ')" "1" "curl call count"
+  assert_file_contains "$TEST_CURL_CALLS" "If-None-Match: \"etag-old\""
+}
+
+test_download_retries_tls_connect_error() {
+  local output="$TMP_DIR/retried"
+  rm -f "$output"
+  unset TEST_CACHED_ETAG TEST_CACHED_TIME TEST_FILE_MTIME
+  export TEST_FAIL_FIRST_GET=1
+  # shellcheck disable=SC1090
+  . "$SCRIPT_UNDER_TEST"
+
+  set +e
+  DOWNLOAD_FILE_CURL "https://example.com/file" "$output" "$output"
+  local rc=$?
+  set -e
+  unset TEST_FAIL_FIRST_GET
+
+  assert_eq "$rc" "0" "download rc"
+  assert_eq "$(cat "$output" 2>/dev/null)" "payload" "downloaded payload"
+  assert_eq "$(wc -l < "$TEST_CURL_CALLS" | tr -d ' ')" "2" "curl call count"
+}
+
+run_case "single_get" test_download_uses_single_get_with_headers
+run_case "not_modified" test_conditional_get_returns_not_modified
+run_case "retry_tls" test_download_retries_tls_connect_error
+
+printf 'openclash_curl tests passed\n'


### PR DESCRIPTION
## Summary

- Avoid the separate `curl -I` preflight in `DOWNLOAD_FILE_CURL`; collect response headers from the real GET request instead, while keeping ETag/304 behavior.
- Download to a temporary file and move it into place only after a successful HTTP 200, with script-level retry for non-progress downloads that hit transient TLS connect errors.
- Move OIX version/core downloads from `dl.dler.io` to GitHub release assets for `vernesong/mihomo-oix`, while preserving existing GitHub mirror handling where applicable.
- Add shell regression tests for the OIX TLS failure pattern, 304 cache behavior, retry behavior, and OIX release URLs.

## Root Cause

On the OIX Mihomo runtime, the current download helper first sends a HEAD request to read ETag and then performs the actual GET. For GitHub/raw endpoints this HEAD -> GET sequence can make the following GET fail with `curl: (35) TLS connect error`, while a single GET that records headers succeeds. OIX core/version downloads also used a non-GitHub `dl.dler.io` endpoint, which is not appropriate for the GitHub-backed core update path.

## Validation

- `bash tests/openclash_curl_test.sh`
- `bash tests/oix_release_url_test.sh`
- `bash -n luci-app-openclash/root/usr/share/openclash/openclash_curl.sh luci-app-openclash/root/usr/share/openclash/clash_version.sh luci-app-openclash/root/usr/share/openclash/openclash_core.sh tests/openclash_curl_test.sh tests/oix_release_url_test.sh`
- `git diff --check`
- OpenWRT/OIX runtime check:
  - `openclash_version.sh` returned 0 and wrote `v0.47.108`
  - `clash_version.sh` returned 0 and wrote `alpha-oix-8b7a89d`
  - `openclash_core.sh Oix` returned 0
  - OIX subscription download through `DOWNLOAD_FILE_CURL` returned 0 and wrote an 18118-byte YAML file
  - `/tmp/openclash.log` showed GitHub and `release-assets.githubusercontent.com` requests matched `RuleSet(PROXY)`
