### PR TITLE
OIX URL-Test 探测地址改用 HTTPS

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -3563,6 +3563,49 @@ get_config()
    uci -q commit openclash
 }
 
+normalize_oix_runtime_urltest_addresses()
+{
+   [ "$core_type" = "Oix" ] || return 0
+   [ -f "$TMP_CONFIG_FILE" ] || return 0
+
+   ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "
+      begin
+         Value = YAML.load_file('$TMP_CONFIG_FILE')
+         oix_safe_urltest_address = 'https://cp.cloudflare.com/generate_204'
+         oix_unstable_urltest_addresses = [
+            'http://captive.apple.com/generate_204',
+            'http://captive.apple.com/',
+            'http://www.gstatic.com/generate_204',
+            'http://cp.cloudflare.com/generate_204',
+            'http://cp.cloudflare.com/'
+         ]
+         normalize_oix_urltest_address = lambda { |url|
+            oix_unstable_urltest_addresses.include?(url.to_s) ? oix_safe_urltest_address : url
+         }
+
+         if Value.key?('proxy-providers')
+            Value['proxy-providers'].each do |name, provider|
+               if provider['health-check'] and provider['health-check']['enable']
+                  provider['health-check']['url'] = normalize_oix_urltest_address.call(provider['health-check']['url'])
+               end
+            end
+         end
+
+         if Value.key?('proxy-groups') and Value['proxy-groups'].is_a?(Array)
+            Value['proxy-groups'].each do |group|
+               if ['url-test', 'fallback', 'load-balance', 'smart'].include?(group['type'])
+                  group['url'] = normalize_oix_urltest_address.call(group['url'])
+               end
+            end
+         end
+
+         File.open('$TMP_CONFIG_FILE', 'w') { |f| YAML.dump(Value, f) }
+      rescue Exception => e
+         YAML.LOG_ERROR('Normalize OIX URL-Test URL Failed,【%s】' % [e.message])
+      end
+      " >> $LOG_FILE 2>&1
+}
+
 start_service()
 {
    enable=$(uci_get_config "enable")
@@ -3637,6 +3680,8 @@ start_service()
                done
             fi
          fi
+
+         normalize_oix_runtime_urltest_addresses
 
          #provider path
          ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "

--- a/luci-app-openclash/root/usr/share/openclash/yml_rules_change.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_rules_change.sh
@@ -7,8 +7,32 @@
 LOG_FILE="/tmp/openclash.log"
 github_address_mod=$(uci_get_config "github_address_mod" || echo 0)
 urltest_address_mod=$(uci_get_config "urltest_address_mod" || echo 0)
+core_type=$(uci_get_config "core_type" || echo Meta)
 tolerance=$(uci_get_config "tolerance" || echo 0)
 urltest_interval_mod=$(uci_get_config "urltest_interval_mod" || echo 0)
+
+normalize_urltest_address_mod()
+{
+   local core_type="$1"
+   local urltest_address="$2"
+
+   if [ "$core_type" = "Oix" ]; then
+      case "$urltest_address" in
+         "http://captive.apple.com/generate_204"|"http://captive.apple.com/"|"http://www.gstatic.com/generate_204"|"http://cp.cloudflare.com/generate_204"|"http://cp.cloudflare.com/")
+            echo "https://cp.cloudflare.com/generate_204"
+            return
+         ;;
+      esac
+   fi
+
+   echo "$urltest_address"
+}
+
+normalized_urltest_address_mod=$(normalize_urltest_address_mod "$core_type" "$urltest_address_mod")
+if [ "$urltest_address_mod" != "$normalized_urltest_address_mod" ]; then
+   LOG_WARN "OIX Core: Replace HTTP URL-Test Address With HTTPS For Better Health-Check Reliability"
+   urltest_address_mod="$normalized_urltest_address_mod"
+fi
 
 yml_other_set()
 {
@@ -417,6 +441,42 @@ yml_other_set()
          end;
 
          threads.each(&:join);
+
+         # OIX providers can report false high latency/timeouts with known HTTP
+         # probe URLs because some providers hijack them or mishandle repeat HEAD.
+         begin
+            if '$core_type' == 'Oix' then
+               oix_safe_urltest_address = 'https://cp.cloudflare.com/generate_204';
+               oix_unstable_urltest_addresses = [
+                  'http://captive.apple.com/generate_204',
+                  'http://captive.apple.com/',
+                  'http://www.gstatic.com/generate_204',
+                  'http://cp.cloudflare.com/generate_204',
+                  'http://cp.cloudflare.com/'
+               ];
+               normalize_oix_urltest_address = lambda { |url|
+                  oix_unstable_urltest_addresses.include?(url.to_s) ? oix_safe_urltest_address : url
+               };
+
+               if Value.key?('proxy-providers') then
+                  Value['proxy-providers'].each{|name, provider|
+                     if provider['health-check'] and provider['health-check']['enable'] then
+                        provider['health-check']['url'] = normalize_oix_urltest_address.call(provider['health-check']['url']);
+                     end;
+                  };
+               end;
+
+               if Value.key?('proxy-groups') and Value['proxy-groups'].is_a?(Array) then
+                  Value['proxy-groups'].each{|group|
+                     if ['url-test', 'fallback', 'load-balance', 'smart'].include?(group['type']) then
+                        group['url'] = normalize_oix_urltest_address.call(group['url']);
+                     end;
+                  };
+               end;
+            end;
+         rescue Exception => e
+            YAML.LOG_ERROR('Normalize OIX URL-Test URL Failed,【' + e.message + '】');
+         end;
       };
 
       thread_pool.each(&:join);

--- a/tests/test_oix_urltest_address_normalization.sh
+++ b/tests/test_oix_urltest_address_normalization.sh
@@ -4,6 +4,7 @@ set -eu
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
 target="$repo_root/luci-app-openclash/root/usr/share/openclash/yml_rules_change.sh"
+init_target="$repo_root/luci-app-openclash/root/etc/init.d/openclash"
 
 fn=$(awk '/^normalize_urltest_address_mod\(\)/,/^}/' "$target")
 
@@ -13,6 +14,16 @@ if [ -z "$fn" ]; then
 fi
 
 eval "$fn"
+
+runtime_fn=$(awk '/^normalize_oix_runtime_urltest_addresses\(\)/,/^}/' "$init_target")
+
+if [ -z "$runtime_fn" ]; then
+  echo "normalize_oix_runtime_urltest_addresses not found" >&2
+  exit 1
+fi
+
+runtime_fn=$(printf '%s\n' "$runtime_fn" | sed "s#ruby -ryaml -rYAML -I \"/usr/share/openclash\" -E UTF-8#ruby -ryaml -E UTF-8#g")
+eval "$runtime_fn"
 
 assert_eq() {
   expected="$1"
@@ -31,3 +42,55 @@ assert_eq "$safe_url" "$(normalize_urltest_address_mod "Oix" "http://www.gstatic
 assert_eq "$safe_url" "$(normalize_urltest_address_mod "Oix" "http://cp.cloudflare.com/generate_204")" "Oix http cloudflare"
 assert_eq "https://www.gstatic.com/generate_204" "$(normalize_urltest_address_mod "Oix" "https://www.gstatic.com/generate_204")" "Oix custom https"
 assert_eq "http://captive.apple.com/generate_204" "$(normalize_urltest_address_mod "Meta" "http://captive.apple.com/generate_204")" "Meta unchanged"
+
+write_runtime_fixture() {
+  file="$1"
+  cat >"$file" <<'YAML'
+proxy-providers:
+  oix-provider:
+    type: http
+    health-check:
+      enable: true
+      url: http://captive.apple.com/generate_204
+  custom-provider:
+    type: http
+    health-check:
+      enable: true
+      url: http://example.com/health
+proxy-groups:
+  - name: auto
+    type: url-test
+    url: http://cp.cloudflare.com/generate_204
+  - name: custom
+    type: fallback
+    url: http://example.com/probe
+YAML
+}
+
+assert_yaml_value() {
+  file="$1"
+  expression="$2"
+  expected="$3"
+  label="$4"
+  actual=$(ruby -ryaml -e "data = YAML.load_file('$file'); puts $expression")
+  assert_eq "$expected" "$actual" "$label"
+}
+
+runtime_tmp=$(mktemp -d "${TMPDIR:-/tmp}/openclash-oix-urltest.XXXXXX")
+trap 'rm -rf "$runtime_tmp"' EXIT
+
+oix_config="$runtime_tmp/oix.yaml"
+write_runtime_fixture "$oix_config"
+core_type=Oix TMP_CONFIG_FILE="$oix_config" LOG_FILE="$runtime_tmp/openclash.log" normalize_oix_runtime_urltest_addresses
+assert_yaml_value "$oix_config" "data['proxy-providers']['oix-provider']['health-check']['url']" "$safe_url" "runtime Oix provider URL"
+assert_yaml_value "$oix_config" "data['proxy-groups'][0]['url']" "$safe_url" "runtime Oix group URL"
+assert_yaml_value "$oix_config" "data['proxy-providers']['custom-provider']['health-check']['url']" "http://example.com/health" "runtime Oix custom provider URL"
+assert_yaml_value "$oix_config" "data['proxy-groups'][1]['url']" "http://example.com/probe" "runtime Oix custom group URL"
+
+meta_config="$runtime_tmp/meta.yaml"
+write_runtime_fixture "$meta_config"
+core_type=Meta TMP_CONFIG_FILE="$meta_config" LOG_FILE="$runtime_tmp/openclash.log" normalize_oix_runtime_urltest_addresses
+assert_yaml_value "$meta_config" "data['proxy-providers']['oix-provider']['health-check']['url']" "http://captive.apple.com/generate_204" "runtime Meta provider unchanged"
+assert_yaml_value "$meta_config" "data['proxy-groups'][0]['url']" "http://cp.cloudflare.com/generate_204" "runtime Meta group unchanged"
+
+echo "test_oix_urltest_address_normalization.sh: PASS"

--- a/tests/test_oix_urltest_address_normalization.sh
+++ b/tests/test_oix_urltest_address_normalization.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+target="$repo_root/luci-app-openclash/root/usr/share/openclash/yml_rules_change.sh"
+
+fn=$(awk '/^normalize_urltest_address_mod\(\)/,/^}/' "$target")
+
+if [ -z "$fn" ]; then
+  echo "normalize_urltest_address_mod not found" >&2
+  exit 1
+fi
+
+eval "$fn"
+
+assert_eq() {
+  expected="$1"
+  actual="$2"
+  label="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$label: expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+safe_url="https://cp.cloudflare.com/generate_204"
+
+assert_eq "$safe_url" "$(normalize_urltest_address_mod "Oix" "http://captive.apple.com/generate_204")" "Oix captive.apple"
+assert_eq "$safe_url" "$(normalize_urltest_address_mod "Oix" "http://www.gstatic.com/generate_204")" "Oix http gstatic"
+assert_eq "$safe_url" "$(normalize_urltest_address_mod "Oix" "http://cp.cloudflare.com/generate_204")" "Oix http cloudflare"
+assert_eq "https://www.gstatic.com/generate_204" "$(normalize_urltest_address_mod "Oix" "https://www.gstatic.com/generate_204")" "Oix custom https"
+assert_eq "http://captive.apple.com/generate_204" "$(normalize_urltest_address_mod "Meta" "http://captive.apple.com/generate_204")" "Meta unchanged"


### PR DESCRIPTION
## 背景

有用户反馈 `alpha-oix` 最新核心下节点显示正常，但 OpenClash 面板访问检查 GitHub / YouTube 出现高延迟、间歇超时，实际使用 YouTube 也会卡顿断流。

我在本地 OpenWrt / OpenClash 环境复核到：

- OpenClash 版本：`0.47.113`
- 核心类型：`Oix`
- OIX 核心版本：`alpha-oix-4bc88c9`
- 生成配置中 provider / url-test 组仍可使用 HTTP 探测地址，例如 `http://captive.apple.com/generate_204` 或 `http://cp.cloudflare.com/generate_204`
- mihomo-oix 日志会提示 HTTP health-check URL 不可靠：部分 provider 会劫持测试地址，或不兼容重复 HEAD 请求，导致健康检查误判

现场还复现到 OIX 数据面持续出现 `local error: tls: bad record MAC` / `broken pipe`，这部分不在本 PR 的 OpenClash 配置生成链路内，仍需要 OIX 核心或节点链路侧继续处理。本 PR 聚焦修复 OpenClash 侧会放大“高延迟/超时”误判的 URL-Test / health-check 配置问题。

## 修复

- OIX 核心下，将已知不可靠的 HTTP 探测地址规范为 `https://cp.cloudflare.com/generate_204`：
  - `http://captive.apple.com/generate_204`
  - `http://captive.apple.com/`
  - `http://www.gstatic.com/generate_204`
  - `http://cp.cloudflare.com/generate_204`
  - `http://cp.cloudflare.com/`
- 对用户通过 `urltest_address_mod` 选择的 HTTP 预设做规范化。
- 对订阅文件自带的 provider `health-check.url` 和 `url-test` / `fallback` / `load-balance` / `smart` group `url` 做最终兜底规范化，避免 `urltest_address_mod=0` 时仍保留 HTTP 探测地址。
- UI 预设只保留 HTTPS 探测地址，降低后续误配置概率。
- 新增 focused shell regression test 覆盖 OIX URL-Test 地址规范化逻辑。

## 验证

本地检查：

```sh
bash -n luci-app-openclash/root/usr/share/openclash/yml_rules_change.sh
bash -n tests/test_oix_urltest_address_normalization.sh
tests/test_oix_urltest_address_normalization.sh
git diff --check --cached
```

路由器现场验证：

- 临时 fixture 验证：即使 `urltest_address_mod=0`，订阅自带 HTTP provider/group URL 也会被补丁改成 `https://cp.cloudflare.com/generate_204`。
- 将现场生成配置中的 provider/group health-check URL 改为 HTTPS 后，`captive.apple` 相关 `context deadline exceeded` 和 HTTP health-check 警告消失。
- GitHub / YouTube 快速探测可成功返回，但 OIX 仍有 `bad record MAC` / `broken pipe`，该残留问题不由本 PR 完全解决。


## 追加修复：覆盖 overwrite 后的最终运行配置

本分支追加了一个启动期兜底：`yml_rules_change.sh` 先完成 OIX URL-Test / health-check 的 HTTPS 规范化后，`/tmp/yaml_overwrite.sh` 或 `/etc/openclash/custom/openclash_custom_overwrite.sh` 仍可能把相同的已知 HTTP 探测地址写回最终运行配置。

根因是启动顺序中 overwrite 阶段在 `yml_rules_change.sh` 之后执行，而后续 provider path 修正只处理 `path`，不再处理 provider health-check 或 group URL。

修复方案是在 overwrite 阶段之后、provider path 最终写回之前，增加 OIX-only 最终规范化：只在 `core_type=Oix` 时精确处理本 PR 已列出的 HTTP 探测地址，只覆盖 `proxy-providers.*.health-check.url` 和 `url-test` / `fallback` / `load-balance` / `smart` group 的 `url`。非 OIX、自定义 HTTP URL、已有 HTTPS URL 均保持不变。

新增验证覆盖：OIX 下 overwrite 后写回的已知 HTTP URL 会再次变为 HTTPS；Meta 下不改；不在名单内的自定义 HTTP URL 不改。
