### PR TITLE
fix: 保留下载失败的 HTTP 状态

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh
@@ -2,6 +2,22 @@
 . /usr/share/openclash/log.sh
 . /usr/share/openclash/openclash_etag.sh
 
+DOWNLOAD_FAILURE_OUTPUT() {
+    failure_exit_code="$1"
+    failure_http_code="$2"
+    failure_output="$3"
+
+    if [ -n "$failure_output" ]; then
+        printf '%s' "$failure_output"
+    elif [ -n "$failure_http_code" ] && [ "$failure_http_code" != "000" ]; then
+        printf 'HTTP status %s' "$failure_http_code"
+    elif [ -n "$failure_exit_code" ]; then
+        printf 'curl exit code %s' "$failure_exit_code"
+    else
+        printf 'unknown error'
+    fi
+}
+
 DOWNLOAD_FILE_CURL() {
     [ -z "$1" ] || [ -z "$2" ] && return 1
     DOWNLOAD_URL=$1
@@ -99,7 +115,8 @@ DOWNLOAD_FILE_CURL() {
         fi
 
         if [ "$EXIR_CODE" -ne 0 ] || [ "$HTTP_CODE" != "200" ]; then
-            LOG_OUT "【$DOWNLOAD_PATH】Download Failed:【$OUTPUT】"
+            OUTPUT=$(DOWNLOAD_FAILURE_OUTPUT "$EXIR_CODE" "$HTTP_CODE" "${OUTPUT:-}")
+            LOG_OUT "【${DOWNLOAD_PATH}】Download Failed:【${OUTPUT}】"
             rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
             SLOG_CLEAN
             return 1
@@ -149,7 +166,8 @@ DOWNLOAD_FILE_CURL() {
 
         if [ "$EXIR_CODE" -ne 0 ] || [ "$HTTP_CODE" != "200" ]; then
             OUTPUT=$(echo "$CURL_OUTPUT" | sed '$d' | grep -a 'curl:' | tail -n 1)
-            LOG_OUT "【$DOWNLOAD_PATH】Download Failed:【$OUTPUT】"
+            OUTPUT=$(DOWNLOAD_FAILURE_OUTPUT "$EXIR_CODE" "$HTTP_CODE" "$OUTPUT")
+            LOG_OUT "【${DOWNLOAD_PATH}】Download Failed:【${OUTPUT}】"
             rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
             SLOG_CLEAN
             return 1
@@ -157,7 +175,7 @@ DOWNLOAD_FILE_CURL() {
     fi
 
     if ! mv -f "$DOWNLOAD_TMP" "$DOWNLOAD_PATH"; then
-        LOG_OUT "【$DOWNLOAD_PATH】Download Failed:【Unable to save download file】"
+        LOG_OUT "【${DOWNLOAD_PATH}】Download Failed:【Unable to save download file】"
         rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
         SLOG_CLEAN
         return 1

--- a/tests/openclash_curl_test.sh
+++ b/tests/openclash_curl_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/openclash-curl-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/usr/share/openclash" "$WORKDIR/bin" "$WORKDIR/tmp"
+
+cat >"$WORKDIR/usr/share/openclash/log.sh" <<'STUB'
+LOG_OUT() {
+  printf '%s\n' "$*" >>"${TEST_LOG:?}"
+}
+SLOG_CLEAN() {
+  :
+}
+STUB
+
+cat >"$WORKDIR/usr/share/openclash/openclash_etag.sh" <<'STUB'
+GET_ETAG_BY_PATH() {
+  return 1
+}
+GET_ETAG_TIMESTAMP_BY_PATH() {
+  return 1
+}
+SAVE_ETAG_TO_CACHE() {
+  :
+}
+STUB
+
+cp "$SCRIPT_UNDER_TEST" "$WORKDIR/openclash_curl.sh"
+perl -0pi -e "s#/usr/share/openclash/#$WORKDIR/usr/share/openclash/#g" "$WORKDIR/openclash_curl.sh"
+
+cat >"$WORKDIR/bin/curl" <<'STUB'
+#!/usr/bin/env sh
+status="${TEST_HTTP_STATUS:-404}"
+header_file=""
+output_file=""
+want_write_out=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -D)
+      header_file="$2"
+      shift 2
+      ;;
+    -o)
+      output_file="$2"
+      shift 2
+      ;;
+    -w)
+      want_write_out=1
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+[ -n "$header_file" ] && printf 'HTTP/2 %s\n' "$status" >"$header_file"
+[ -n "$output_file" ] && printf 'not found\n' >"$output_file"
+[ "$want_write_out" -eq 1 ] && printf '\n%s\n' "$status"
+exit 0
+STUB
+chmod +x "$WORKDIR/bin/curl"
+
+assert_log_contains() {
+  local expected="$1"
+  if ! grep -F "$expected" "$TEST_LOG" >/dev/null 2>&1; then
+    echo "expected log to contain: $expected" >&2
+    echo "actual log:" >&2
+    sed -n '1,120p' "$TEST_LOG" >&2 || true
+    exit 1
+  fi
+}
+
+run_download() {
+  local progress="$1"
+  TEST_LOG="$WORKDIR/curl-${progress}.log"
+  export TEST_LOG TEST_HTTP_STATUS=404
+  : >"$TEST_LOG"
+
+  set +e
+  PATH="$WORKDIR/bin:$PATH" SHOW_DOWNLOAD_PROGRESS="$progress" bash -c \
+    ". '$WORKDIR/openclash_curl.sh'; DOWNLOAD_FILE_CURL 'https://example.invalid/file' '$WORKDIR/tmp/file.bin' '$WORKDIR/tmp/file.bin'"
+  local status=$?
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    echo "expected HTTP 404 download to fail" >&2
+    exit 1
+  fi
+  assert_log_contains "HTTP status 404"
+}
+
+run_download 0
+run_download 1
+
+echo "openclash_curl_test.sh: PASS"


### PR DESCRIPTION
## 问题现象

GitHub/CDN/网关返回 404、502 等 HTTP 错误时，`DOWNLOAD_FILE_CURL` 会失败，但日志只显示空的 `Download Failed`，实际 HTTP 状态不可见，排查时容易把远端资源路径、CDN 网关错误和本地网络故障混在一起。

## 根因

`openclash_curl.sh` 只从 curl stderr 提取 `curl:` 行；HTTP 非 200 但 curl 自身退出码为 0 时没有错误文本。同时日志字符串里变量紧贴中文右括号，部分 shell/locale 下会让变量展开结果丢失。

## 修复方案

- 新增失败详情生成：优先保留 curl 错误，其次记录 `HTTP status <code>`，再退回 curl exit code。
- 对失败日志中的变量使用 `${...}`，避免变量名边界被后续字符影响。
- 不改变下载 URL、重试、ETag、304、临时文件或返回码语义。

## 与已有开启态 PR 的关系

- OpenClash #5193 覆盖 dashboard 内容校验和原子替换，不覆盖通用下载失败日志。
- OpenClash #5197 覆盖自动版本更新路径和失败返回码，不覆盖 `DOWNLOAD_FILE_CURL` 的非 200 可观察性。
- mihomo-oix #8 覆盖 OIX core updater 的非 200 状态码校验，这是 core 仓库问题；本 PR 只修 OpenClash shell 下载器日志。

## 验证

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`
- `bash -n tests/*.sh`
- `bash tests/openclash_curl_test.sh`
- `git diff --check`
- `rg '<<<<<<<|=======|>>>>>>>' luci-app-openclash/root/usr/share/openclash tests` 无匹配

## 剩余风险

未做路由器 live 下载验证；本地测试通过 mock curl 覆盖进度和非进度两条失败路径。
