### PR TITLE
fix: 分离 fw4 IPv4/IPv6 DNS 劫持判断

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -917,6 +917,21 @@ ipv6_suffix_to_nft_format()
    echo "& ${suffix} == ${addr}"
 } 2>/dev/null
 
+fw4_has_dns_hijack_rule()
+{
+   local chain="$1"
+   local family="$2"
+
+   case "$family" in
+      ipv6)
+         nft list chain inet fw4 "$chain" 2>/dev/null |grep 'OpenClash DNS Hijack' |grep -Eq 'meta nfproto[[:space:]]+\{?ipv6\}?|meta nfproto[[:space:]]+ipv6|ip6 nexthdr'
+      ;;
+      *)
+         nft list chain inet fw4 "$chain" 2>/dev/null |grep 'OpenClash DNS Hijack' |grep -Evq 'meta nfproto[[:space:]]+\{?ipv6\}?|meta nfproto[[:space:]]+ipv6|ip6 nexthdr'
+      ;;
+   esac
+}
+
 firewall_lan_ac_traffic()
 {
    local src_port sport_rule dscp_rule sport_ipt dscp_ipt src_ip src_ip_v6 proto target target_ enabled family dscp rule output_rule comment
@@ -1319,7 +1334,7 @@ if [ -n "$FW4" ]; then
    fi
 
    if [ "$enable_redirect_dns" -eq 1 ]; then
-      if [ -z "$(nft list chain inet fw4 dstnat |grep 'OpenClash DNS Hijack')" ]; then
+      if ! fw4_has_dns_hijack_rule dstnat ipv4; then
          if [ "$lan_ac_mode" != "1" ]; then
             ACBLACKDNSFILTER=""
             if [ "$lan_ac_mode" = "0" ]; then
@@ -1681,7 +1696,7 @@ if [ -n "$FW4" ]; then
          fi
       fi
 
-      if [ -z "$(nft list chain inet fw4 dstnat |grep 'OpenClash DNS Hijack')" ]; then
+      if ! fw4_has_dns_hijack_rule dstnat ipv6; then
          if [ "$enable_redirect_dns" -eq 1 ]; then
             if [ "$lan_ac_mode" != "1" ]; then
                ACBLACKDNSFILTER=""

--- a/tests/fw4_dns_hijack_guard_test.sh
+++ b/tests/fw4_dns_hijack_guard_test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INIT_SCRIPT="$REPO_ROOT/luci-app-openclash/root/etc/init.d/openclash"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/openclash-fw4-dns-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+fn=$(awk '/^fw4_has_dns_hijack_rule\(\)/,/^}/' "$INIT_SCRIPT")
+if [ -z "$fn" ]; then
+  echo "fw4_has_dns_hijack_rule not found" >&2
+  exit 1
+fi
+eval "$fn"
+
+cat >"$WORKDIR/nft" <<'STUB'
+#!/usr/bin/env sh
+if [ "$*" = "list chain inet fw4 dstnat" ]; then
+  cat "${TEST_NFT_DSTNAT:?}"
+elif [ "$*" = "list chain inet fw4 nat_output" ]; then
+  cat "${TEST_NFT_NAT_OUTPUT:?}"
+fi
+STUB
+chmod +x "$WORKDIR/nft"
+
+assert_status() {
+  expected="$1"
+  shift
+  set +e
+  PATH="$WORKDIR:$PATH" "$@"
+  actual=$?
+  set -e
+  if [ "$actual" -ne "$expected" ]; then
+    echo "expected status $expected, got $actual: $*" >&2
+    exit 1
+  fi
+}
+
+TEST_NFT_DSTNAT="$WORKDIR/dstnat.txt"
+TEST_NFT_NAT_OUTPUT="$WORKDIR/nat_output.txt"
+export TEST_NFT_DSTNAT TEST_NFT_NAT_OUTPUT
+
+cat >"$TEST_NFT_DSTNAT" <<'EOF'
+meta l4proto { tcp, udp } th dport 53 counter redirect to :53 comment "OpenClash DNS Hijack"
+EOF
+cat >"$TEST_NFT_NAT_OUTPUT" <<'EOF'
+meta l4proto { tcp, udp } th dport 53 ip daddr 127.0.0.1 counter redirect to :53 comment "OpenClash DNS Hijack"
+EOF
+
+assert_status 0 fw4_has_dns_hijack_rule dstnat ipv4
+assert_status 1 fw4_has_dns_hijack_rule dstnat ipv6
+assert_status 0 fw4_has_dns_hijack_rule nat_output ipv4
+assert_status 1 fw4_has_dns_hijack_rule nat_output ipv6
+
+cat >"$TEST_NFT_DSTNAT" <<'EOF'
+meta nfproto ipv6 ip6 nexthdr { tcp, udp } th dport 53 counter redirect to :53 comment "OpenClash DNS Hijack"
+EOF
+cat >"$TEST_NFT_NAT_OUTPUT" <<'EOF'
+skgid != 65534 meta nfproto ipv6 ip6 nexthdr { tcp, udp } th dport 53 ip6 daddr ::/0 counter redirect to :53 comment "OpenClash DNS Hijack"
+EOF
+
+assert_status 1 fw4_has_dns_hijack_rule dstnat ipv4
+assert_status 0 fw4_has_dns_hijack_rule dstnat ipv6
+assert_status 1 fw4_has_dns_hijack_rule nat_output ipv4
+assert_status 0 fw4_has_dns_hijack_rule nat_output ipv6
+
+echo "fw4_dns_hijack_guard_test.sh: PASS"


### PR DESCRIPTION
## 问题现象

fw4/nftables 环境启用 IPv6、`enable_redirect_dns=1` 时，IPv4 DNS 劫持规则先写入 `dstnat` 后，IPv6 DNS 劫持分支可能被同一个 `OpenClash DNS Hijack` 注释检查短路，最终 IPv6 LAN DNS 和 router-self IPv6 DNS 没有进入预期重定向路径。

## 根因

fw4 IPv4 和 IPv6 分支都用 `nft list chain inet fw4 dstnat | grep 'OpenClash DNS Hijack'` 判断是否已有 DNS 规则。IPv4 分支先执行后，IPv6 分支只看到同名注释就跳过，没有区分 IPv4/IPv6 规则特征。

## 修复方案

- 新增 `fw4_has_dns_hijack_rule(chain, family)`，按 `meta nfproto ipv6` / `ip6 nexthdr` 区分 IPv6 DNS 规则。
- IPv4 guard 只判断 IPv4 DNS 劫持是否已存在；IPv6 guard 只判断 IPv6 DNS 劫持是否已存在。
- 不改实际 nft redirect 规则，不改 iptables 分支，不改 dnsmasq/UCI 逻辑。

## 与已有开启态 PR 的关系

OpenClash #5191/#5193/#5197/#5198/#5202、mihomo-oix #8、mihomo #10 均不触及 fw4 IPv4/IPv6 DNS guard。该修复独立于 OIX 数据面和系统 feed 下载路径。

## 验证

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`
- `bash -n luci-app-openclash/root/etc/init.d/openclash`
- `bash -n tests/*.sh`
- `bash tests/fw4_dns_hijack_guard_test.sh`
- `git diff --check`
- `rg '<<<<<<<|=======|>>>>>>>' luci-app-openclash/root/etc/init.d/openclash tests` 无匹配

## 剩余风险

未做 live nft 规则验证；本地测试用 mock `nft list` 覆盖 IPv4-only 和 IPv6-only 两种 guard 判定。
