### PR TITLE
fix: 原子替换核心文件

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
@@ -63,9 +63,9 @@ else
    mkdir -p /tmp/etc/openclash/core
 fi
 
-CORE_CV=$($meta_core_path -v 2>/dev/null |awk -F ' ' '{print $3}' |head -1)
-TMP_FILE="/tmp/clash_meta"
 TARGET_CORE_PATH="$meta_core_path"
+CORE_CV=$($TARGET_CORE_PATH -v 2>/dev/null |awk -F ' ' '{print $3}' |head -1)
+TMP_FILE="${TARGET_CORE_PATH}.new.$$"
 
 if [ "$CORE_TYPE" = "Oix" ]; then
    CORE_URL_PATH=""
@@ -149,7 +149,7 @@ if [ "$CORE_CV" != "$CORE_LV" ] || [ -z "$CORE_CV" ]; then
                   fi
                fi
 
-               mv "$TMP_FILE" "$TARGET_CORE_PATH" >/dev/null 2>&1
+               mv -f "$TMP_FILE" "$TARGET_CORE_PATH" >/dev/null 2>&1
 
                if [ "$?" == "0" ]; then
                   LOG_TIP "【"$CORE_TYPE"】Core Update Successful!"

--- a/tests/openclash_core_atomic_test.sh
+++ b/tests/openclash_core_atomic_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_core.sh"
+
+if grep -F 'TMP_FILE="/tmp/clash_meta"' "$SCRIPT" >/dev/null 2>&1; then
+  echo "core staging still uses /tmp/clash_meta" >&2
+  exit 1
+fi
+
+if ! grep -F 'TMP_FILE="${TARGET_CORE_PATH}.new.$$"' "$SCRIPT" >/dev/null 2>&1; then
+  echo "core staging is not created next to target core" >&2
+  exit 1
+fi
+
+if ! grep -F 'mv -f "$TMP_FILE" "$TARGET_CORE_PATH"' "$SCRIPT" >/dev/null 2>&1; then
+  echo "core replacement does not use final same-directory mv" >&2
+  exit 1
+fi
+
+echo "openclash_core_atomic_test.sh: PASS"


### PR DESCRIPTION
## 问题现象

核心更新时，下载和校验后的临时核心固定放在 `/tmp/clash_meta`，最后再移动到 `/etc/openclash/core/clash_meta` 或小闪存路径。在常见 OpenWrt 环境中 `/tmp` 可能是 tmpfs、`/etc` 是 overlay，跨文件系统移动会退化为复制/删除，不具备最终替换的原子性。

## 根因

`openclash_core.sh` 使用固定 `/tmp/clash_meta` 作为 staging 文件。最终替换时如果跨文件系统、空间不足或中断，旧核心的安全边界弱于同目录临时文件加同目录 rename。

## 修复方案

- 将 staging 文件改为 `${TARGET_CORE_PATH}.new.$$`，位于目标核心同目录。
- gzip/tar 解包、`chmod`、`core -v` 校验仍在替换前完成。
- 最终使用 `mv -f "$TMP_FILE" "$TARGET_CORE_PATH"`，在目标目录内完成替换。
- 不改下载 URL、重试、OIX/Meta/Smart 选择、gzip/tar 校验或失败日志。

## 与已有开启态 PR 的关系

OpenClash #5197 涉及自动更新和核心更新失败返回码/OIX URL，但不改变核心文件 staging 位置；OpenClash #5193 只覆盖 dashboard 替换；mihomo-oix #8 是 core updater HTTP 状态码校验。该 PR 只修 OpenClash core 文件替换边界。

## 验证

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`
- `bash -n tests/*.sh`
- `bash tests/openclash_core_atomic_test.sh`
- `git diff --check`
- `rg '<<<<<<<|=======|>>>>>>>' luci-app-openclash/root/usr/share/openclash tests` 无匹配

## 剩余风险

未在真实路由器上模拟断电或磁盘满；测试是针对脚本 staging/rename 结构的 focused regression。
