### PR TITLE
fix: 修复 watchdog UPNP 动态规则刷新

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh
@@ -313,7 +313,7 @@ fi
       if [ -f "$upnp_lease_file" ]; then
          #del
          if [ -n "$FW4" ]; then
-            for i in `$(nft list chain inet fw4 openclash_upnp |grep "return")`
+            nft list chain inet fw4 openclash_upnp 2>/dev/null |grep "return" |while read -r i
             do
                upnp_ip=$(echo "$i" |awk -F 'ip saddr ' '{print $2}' |awk  '{print $1}')
                upnp_dp=$(echo "$i" |awk -F 'sport ' '{print $2}' |awk  '{print $1}')
@@ -326,7 +326,7 @@ fi
                fi
             done >/dev/null 2>&1
          else
-            for i in `$(iptables -t mangle -nL openclash_upnp |grep "RETURN")`
+            iptables -t mangle -nL openclash_upnp 2>/dev/null |grep "RETURN" |while read -r i
             do
                upnp_ip=$(echo "$i" |awk '{print $4}')
                upnp_dp=$(echo "$i" |awk -F 'spt:' '{print $2}')
@@ -339,7 +339,7 @@ fi
             done >/dev/null 2>&1
          fi
          #add
-         if [ -s "$upnp_lease_file" ] && [ -n "$(iptables --line-numbers -t nat -xnvL openclash_upnp 2>/dev/null)"] || [ -n "$(nft list chain inet fw4 openclash_upnp 2>/dev/null)"]; then
+         if [ -s "$upnp_lease_file" ] && { { [ -z "$FW4" ] && [ -n "$(iptables --line-numbers -t mangle -xnvL openclash_upnp 2>/dev/null)" ]; } || { [ -n "$FW4" ] && [ -n "$(nft list chain inet fw4 openclash_upnp 2>/dev/null)" ]; }; }; then
             cat "$upnp_lease_file" |while read -r line
             do
                if [ -n "$line" ]; then

--- a/tests/openclash_watchdog_upnp_test.sh
+++ b/tests/openclash_watchdog_upnp_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh"
+
+if grep -F 'for i in `$(' "$SCRIPT" >/dev/null 2>&1; then
+  echo "UPNP delete loop still executes listed rules as commands" >&2
+  exit 1
+fi
+
+if grep -F 'iptables --line-numbers -t nat -xnvL openclash_upnp' "$SCRIPT" >/dev/null 2>&1; then
+  echo "UPNP add guard still checks nat instead of mangle" >&2
+  exit 1
+fi
+
+if ! grep -F 'iptables --line-numbers -t mangle -xnvL openclash_upnp' "$SCRIPT" >/dev/null 2>&1; then
+  echo "UPNP add guard does not check the mangle openclash_upnp chain" >&2
+  exit 1
+fi
+
+if grep -F '2>/dev/null)"]' "$SCRIPT" >/dev/null 2>&1; then
+  echo "UPNP add guard still has a missing test bracket space" >&2
+  exit 1
+fi
+
+echo "openclash_watchdog_upnp_test.sh: PASS"


### PR DESCRIPTION
## 问题现象

watchdog 的 UPNP 动态刷新分支可能无法可靠删除已失效租约规则，也可能因新增 guard 写错链和 test 语法而无法追加新租约规则。结果是新 UPNP 租约流量继续进入透明代理，或旧租约 RETURN 规则残留。

## 根因

- 删除旧规则时使用 ``for i in `$(...)` ``，会尝试执行规则列表文本，而不是逐行读取规则。
- 新增规则 guard 检查 `iptables -t nat openclash_upnp`，但实际 openclash_upnp 链在 mangle 表。
- 同一 guard 的 `]` 前缺少空格，运行时语法不可靠。

## 修复方案

- 将 nft/iptables 规则列表改为管道 `while read -r` 逐行处理。
- iptables guard 改查 mangle 表；fw4 仍检查 nft `inet fw4 openclash_upnp`。
- 链不存在时列表命令静默失败，不污染 watchdog 日志。
- 不改初始 firewall 生成、不改租约字段解析、不改 DNS/OIX/provider 逻辑。

## 与已有开启态 PR 的关系

OpenClash #5191 也触及 `openclash_watchdog.sh`，但目标是 OIX provider 地址提取；本 PR 只修 UPNP 动态刷新。OpenClash #5197/#5202 以及 core 侧 PR 均不覆盖该逻辑。

## 验证

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`
- `sh -n luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh`
- `bash -n tests/*.sh`
- `bash tests/openclash_watchdog_upnp_test.sh`
- `git diff --check`
- `rg '<<<<<<<|=======|>>>>>>>' luci-app-openclash/root/usr/share/openclash tests` 无匹配

## 剩余风险

未做 live UPNP 租约验证；测试以脚本结构防回归为主，未模拟完整 nft/iptables 规则表。
