### PR TITLE
fix: 保留系统包管理器锁状态

### DIFF
--- a/luci-app-openclash/luasrc/controller/openclash.lua
+++ b/luci-app-openclash/luasrc/controller/openclash.lua
@@ -190,9 +190,9 @@ local function coremodel()
 		return opkg.info("libc")["libc"]["Architecture"]
 	else
 		if fs.pkg_type() == "opkg" then
-			return luci.sys.exec("rm -f /var/lock/opkg.lock && opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' 2>/dev/null")
+			return luci.sys.exec("opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' 2>/dev/null")
 		else
-			return luci.sys.exec("rm -f /lib/apk/db/lock && apk list libc 2>/dev/null |awk '{print $2}'")
+			return luci.sys.exec("apk list libc 2>/dev/null |awk '{print $2}'")
 		end
 	end
 end
@@ -246,9 +246,9 @@ local function opcv()
 		v = info["luci-app-openclash"]["Version"]
 	else
 		if fs.pkg_type() == "opkg" then
-			v = luci.sys.exec("rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' |tr -d '\n'")
+			v = luci.sys.exec("opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' |tr -d '\n'")
 		else
-			v = luci.sys.exec("rm -f /lib/apk/db/lock && apk list luci-app-openclash 2>/dev/null|grep 'installed' | grep -oE '[0-9]+(\\.[0-9]+)*' | head -1 |tr -d '\n'")
+			v = luci.sys.exec("apk list luci-app-openclash 2>/dev/null|grep 'installed' | grep -oE '[0-9]+(\\.[0-9]+)*' | head -1 |tr -d '\n'")
 		end
 	end
 	if v and v ~= "" then

--- a/luci-app-openclash/luasrc/openclash.lua
+++ b/luci-app-openclash/luasrc/openclash.lua
@@ -606,9 +606,9 @@ end
 function oc_version()
 	local v
 	if pkg_type() == "opkg" then
-		v = SYS.exec("rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep '^Version:' |awk '{print $2}' |tr -d '\n'")
+		v = SYS.exec("opkg status luci-app-openclash 2>/dev/null |grep '^Version:' |awk '{print $2}' |tr -d '\n'")
 	else
-		v = SYS.exec("rm -f /lib/apk/db/lock && apk info luci-app-openclash 2>/dev/null |grep '^luci-app-openclash-[0-9]' |sed 's/luci-app-openclash-//' |tr -d '\n'")
+		v = SYS.exec("apk info luci-app-openclash 2>/dev/null |grep '^luci-app-openclash-[0-9]' |sed 's/luci-app-openclash-//' |tr -d '\n'")
 	end
 	if v == "" then
 		v = "0"

--- a/luci-app-openclash/root/usr/share/openclash/openclash_debug.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_debug.sh
@@ -16,9 +16,9 @@ del_lock() {
 ipk_v()
 {
    if [ -x "/bin/opkg" ]; then
-      echo $(rm -f /var/lock/opkg.lock && opkg status "$1" 2>/dev/null |grep 'Version' |awk -F ': ' '{print $2}' 2>/dev/null)
+      echo $(opkg status "$1" 2>/dev/null |grep 'Version' |awk -F ': ' '{print $2}' 2>/dev/null)
    elif [ -x "/usr/bin/apk" ]; then
-      echo $(rm -f /lib/apk/db/lock && apk list "$1" 2>/dev/null |grep 'installed' | grep -oE '\d+(\.\d+)*' | head -1)
+      echo $(apk list "$1" 2>/dev/null |grep 'installed' | grep -oE '\d+(\.\d+)*' | head -1)
    fi
 }
 
@@ -42,9 +42,9 @@ RAW_CONFIG_FILE=$(uci_get_config "config_path")
 CONFIG_FILE="/etc/openclash/$(uci_get_config "config_path" |awk -F '/' '{print $5}' 2>/dev/null)"
 core_model=$(uci_get_config "core_version")
 if [ -x "/bin/opkg" ]; then
-   cpu_model=$(rm -f /var/lock/opkg.lock && opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' 2>/dev/null)
+   cpu_model=$(opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' 2>/dev/null)
 elif [ -x "/usr/bin/apk" ]; then
-   cpu_model=$(rm -f /lib/apk/db/lock && apk list libc 2>/dev/null|awk '{print $2}')
+   cpu_model=$(apk list libc 2>/dev/null|awk '{print $2}')
 fi
 core_meta_version=$(/etc/openclash/core/clash_meta -v 2>/dev/null |awk -F ' ' '{print $3}' |head -1 2>/dev/null)
 op_version=$(ipk_v "luci-app-openclash")

--- a/luci-app-openclash/root/usr/share/openclash/openclash_history_get.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_history_get.sh
@@ -50,7 +50,7 @@ if [ -z "$CONFIG_FILE" ] || [ ! -f "$CONFIG_FILE" ]; then
 fi
 
 if [ -n "$(pidof clash)" ] && [ -f "$CONFIG_FILE" ]; then
-   if [ "$small_flash_memory" == "1" ] || [ -n "$(echo $core_version |grep mips)" ] || [ -n "$(echo $DISTRIB_ARCH |grep mips)" ] || [ -n "$(rm -f /var/lock/opkg.lock && opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' |grep mips)" ] || [ -n "$(rm -f /lib/apk/db/lock && apk list libc 2>/dev/null |grep mips)" ]; then
+   if [ "$small_flash_memory" == "1" ] || [ -n "$(echo $core_version |grep mips)" ] || [ -n "$(echo $DISTRIB_ARCH |grep mips)" ] || [ -n "$(opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' |grep mips)" ] || [ -n "$(apk list libc 2>/dev/null |grep mips)" ]; then
       CACHE_PATH="/tmp/etc/openclash/cache.db"
       if [ -f "$CACHE_PATH" ]; then
          cmp -s "$CACHE_PATH" "$HISTORY_PATH"

--- a/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
@@ -73,9 +73,9 @@ run_with_timeout() {
 LAST_OPVER="/tmp/openclash_last_version"
 LAST_VER=$(sed -n 1p "$LAST_OPVER" 2>/dev/null |sed "s/^v//g" |tr -d "\n")
 if [ -x "/bin/opkg" ]; then
-   OP_CV=$(rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
+   OP_CV=$(opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
 elif [ -x "/usr/bin/apk" ]; then
-   OP_CV=$(rm -f /lib/apk/db/lock && apk list luci-app-openclash 2>/dev/null|grep "installed" | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
+   OP_CV=$(apk list luci-app-openclash 2>/dev/null|grep "installed" | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
 fi
 OP_LV=$(sed -n 1p "$LAST_OPVER" 2>/dev/null |sed "s/^v//g" |tr -d "\n")
 RELEASE_BRANCH=$(uci_get_config "release_branch" || echo "master")
@@ -156,7 +156,6 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
                update_retry=$((update_retry + 1))
                run_with_timeout 30 opkg update >/dev/null 2>&1
                opkg_ret=$?
-               rm -f /var/lock/opkg.lock
                if [ $opkg_ret -eq 0 ]; then
                   break
                fi
@@ -179,7 +178,6 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
                update_retry=$((update_retry + 1))
                run_with_timeout 30 apk update >/dev/null 2>&1
                apk_ret=$?
-               rm -f /lib/apk/db/lock
                if [ $apk_ret -eq 0 ]; then
                   break
                fi
@@ -265,7 +263,7 @@ check_install_success()
    local current_version=""
 
    if [ -x "/bin/opkg" ]; then
-      current_version=$(rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
+      current_version=$(opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
    elif [ -x "/usr/bin/apk" ]; then
       current_version=$(apk list luci-app-openclash 2>/dev/null |grep "installed" | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
    fi

--- a/luci-app-openclash/root/usr/share/openclash/openclash_version.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_version.sh
@@ -35,9 +35,9 @@ version_compare() {
 DOWNLOAD_FILE="/tmp/openclash_last_version"
 RELEASE_BRANCH=$(uci_get_config "release_branch" || echo "master")
 if [ -x "/bin/opkg" ]; then
-   OP_CV=$(rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
+   OP_CV=$(opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
 elif [ -x "/usr/bin/apk" ]; then
-   OP_CV=$(rm -f /lib/apk/db/lock && apk list luci-app-openclash 2>/dev/null|grep 'installed' | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
+   OP_CV=$(apk list luci-app-openclash 2>/dev/null|grep 'installed' | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
 fi
 OP_LV=$(sed -n 1p "$DOWNLOAD_FILE" 2>/dev/null |sed "s/^v//g" |tr -d "\n")
 github_address_mod=$(uci_get_config "github_address_mod" || echo 0)

--- a/tests/openclash_package_lock_test.sh
+++ b/tests/openclash_package_lock_test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MATCH_FILE="${TMPDIR:-/tmp}/openclash-package-lock-rm.$$"
+trap 'rm -f "$MATCH_FILE"' EXIT
+
+if grep -RInE 'rm -.*(/var/lock/opkg\.lock|/lib/apk/db/lock)' \
+  "$REPO_ROOT/luci-app-openclash" >"$MATCH_FILE"; then
+  echo "OpenClash scripts must not remove system package manager locks:" >&2
+  cat "$MATCH_FILE" >&2
+  exit 1
+fi
+
+echo "openclash_package_lock_test.sh: PASS"


### PR DESCRIPTION
## Dependency chain

无依赖，可独立合并。建议先于自动更新类改动合并，避免后续更新路径继续继承系统锁误删行为。

## 问题现象

OpenClash 在版本显示、调试信息、历史缓存判断和版本更新预检查中，会直接删除 `/var/lock/opkg.lock` 或 `/lib/apk/db/lock`。如果系统里同时有 LuCI、用户 shell 或系统 feed 操作在运行，这会绕过包管理器自身互斥，让两个包管理流程并发访问同一数据库。

## 根因

这些路径只是读取包版本、CPU 架构或执行 `opkg update` / `apk update`，但代码在读取前后无条件 `rm -f` 系统包管理器锁文件。锁文件属于 opkg/apk 的互斥状态，不应由 OpenClash 的查询脚本清理。

## 证据

- `openclash_update.sh` 原先在读取当前版本、`opkg update` / `apk update` 后、安装脚本校验版本时删除系统锁。
- `openclash_version.sh`、`openclash_debug.sh`、`openclash_history_get.sh` 原先在只读查询前删除系统锁。
- LuCI helper `luasrc/openclash.lua` 和 controller 中也存在同类只读查询前删锁。
- 新增 `tests/openclash_package_lock_test.sh` 对整个 `luci-app-openclash` 做回归扫描，防止这些路径重新引入系统锁删除。

## 修复方案

- 移除 OpenClash 运行时脚本和 LuCI 查询路径中的系统包管理器锁删除。
- 保留原有 `opkg status`、`apk list/info`、`opkg update`、`apk update` 调用和错误处理，不改变下载代理、重试次数或安装流程。
- 新增 focused test，要求仓库内不再出现删除 opkg/apk 系统锁的代码。

## 为什么没有扩大范围

本 PR 只处理“OpenClash 不应删除系统包管理器锁”这一项。后台安装期间固定包路径、OpenClash 自有 `flock` 锁文件删除、启动状态判断等是独立竞态问题，应单独审查和提交，避免把不同风险混成一个大改动。

## 与已有开启态 PR 的关系

- #5197 涉及自动版本更新入口和退出状态，但没有移除系统包管理器锁删除；本 PR 可作为其前置健壮性修复。
- #5198 以及 vernesong/mihomo#10 是 Smart 粘性会话相关，互不相关。
- 已合入的 #5193/#5208/#5209/#5210/#5211 分别覆盖 dashboard 校验、下载失败状态、fw4 DNS guard、核心文件替换、watchdog UPNP，不覆盖本问题。

## 验证

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`：通过
- `bash -n luci-app-openclash/root/etc/init.d/openclash`：通过
- `bash -n tests/*.sh`：通过
- `for t in tests/*.sh; do bash "$t"; done`：全部通过
- `git diff --check`：通过
- `rg -n '^(<<<<<<<|=======|>>>>>>>)'`：无匹配

未做 live router 写入验证；本次不触碰真实路由器配置和包数据库。

## 剩余风险

如果 `opkg update` 或 `apk update` 被超时强杀后包管理器自身留下不可恢复的 stale lock，需要另行做 owner-aware 的超时恢复策略；本 PR 不恢复无条件删锁行为。
