### PR TITLE
fix: 保持 flock 锁文件稳定

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/clash_version.sh
+++ b/luci-app-openclash/root/usr/share/openclash/clash_version.sh
@@ -9,7 +9,6 @@ set_lock() {
 
 del_lock() {
    flock -u 884 2>/dev/null
-   rm -rf "/tmp/lock/openclash_clash_version.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash.sh
@@ -14,7 +14,6 @@ set_lock() {
 
 del_lock() {
    flock -u 889 2>/dev/null
-   rm -rf "/tmp/lock/openclash_subs.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_chnroute.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_chnroute.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 879 2>/dev/null
-   rm -rf "/tmp/lock/openclash_chn.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
@@ -12,7 +12,6 @@ set_lock() {
 
 del_lock() {
    flock -u 872 2>/dev/null
-   rm -rf "/tmp/lock/openclash_core.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_custom_domain_dns.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_custom_domain_dns.sh
@@ -9,7 +9,6 @@ set_lock() {
 
 del_lock() {
    flock -u 883 2>/dev/null
-   rm -rf "/tmp/lock/openclash_cus_domian.lock"
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_debug.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_debug.sh
@@ -10,7 +10,6 @@ set_lock() {
 
 del_lock() {
    flock -u 885 2>/dev/null
-   rm -rf "/tmp/lock/openclash_debug.lock" 2>/dev/null
 }
 
 ipk_v()

--- a/luci-app-openclash/root/usr/share/openclash/openclash_download_dashboard.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_download_dashboard.sh
@@ -11,7 +11,6 @@
 
    del_lock() {
       flock -u 871 2>/dev/null
-      rm -rf "/tmp/lock/openclash_dashboard.lock" 2>/dev/null
    }
 
    validate_dashboard_dir() {

--- a/luci-app-openclash/root/usr/share/openclash/openclash_geo.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_geo.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 888 2>/dev/null
-   rm -rf "/tmp/lock/openclash_update_databases.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_history_get.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_history_get.sh
@@ -10,7 +10,6 @@ set_lock() {
 
 del_lock() {
    flock -u 881 2>/dev/null
-   rm -rf "/tmp/lock/openclash_history_get.lock" 2>/dev/null
 }
 
 close_all_conection() {

--- a/luci-app-openclash/root/usr/share/openclash/openclash_lgbm.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_lgbm.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 868 2>/dev/null
-   rm -rf "/tmp/lock/openclash_lgbm.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 878 2>/dev/null
-   rm -rf "/tmp/lock/openclash_update.lock" 2>/dev/null
 }
 
 set_lock
@@ -249,7 +248,6 @@ set_update_lock() {
 
 del_update_lock() {
    flock -u 879 2>/dev/null
-   rm -rf "$UPDATE_LOCK" 2>/dev/null
 }
 
 if ! set_update_lock; then

--- a/luci-app-openclash/root/usr/share/openclash/openclash_version.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_version.sh
@@ -9,7 +9,6 @@ set_lock() {
 
 del_lock() {
    flock -u 869 2>/dev/null
-   rm -rf "/tmp/lock/openclash_version.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/yml_groups_get.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_groups_get.sh
@@ -10,7 +10,6 @@ set_lock() {
 
 del_lock() {
    flock -u 876 2>/dev/null
-   rm -rf "/tmp/lock/openclash_groups_get.lock"
 }
 
 CONFIG_FILE=$(uci_get_config "config_path")

--- a/luci-app-openclash/root/usr/share/openclash/yml_groups_set.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_groups_set.sh
@@ -10,7 +10,6 @@ set_lock() {
 
 del_lock() {
    flock -u 887 2>/dev/null
-   rm -rf "/tmp/lock/openclash_groups_set.lock"
 }
 
 set_lock
@@ -329,4 +328,3 @@ sed -i "s/#delete_//g" "$CONFIG_FILE" 2>/dev/null
 
 /usr/share/openclash/yml_proxys_set.sh "$CONFIG_FILE" >/dev/null 2>&1
 del_lock
-

--- a/luci-app-openclash/root/usr/share/openclash/yml_proxys_get.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_proxys_get.sh
@@ -10,7 +10,6 @@ set_lock() {
 
 del_lock() {
    flock -u 875 2>/dev/null
-   rm -rf "/tmp/lock/openclash_proxies_get.lock"
 }
 
 CONFIG_FILE=$(uci_get_config "config_path")

--- a/luci-app-openclash/root/usr/share/openclash/yml_proxys_set.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_proxys_set.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 886 2>/dev/null
-   rm -rf "/tmp/lock/openclash_proxies_set.lock"
 }
 
 SERVER_FILE="/tmp/yaml_servers.yaml"

--- a/tests/openclash_flock_lockfile_test.sh
+++ b/tests/openclash_flock_lockfile_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MATCH_FILE="${TMPDIR:-/tmp}/openclash-flock-lock-rm.$$"
+trap 'rm -f "$MATCH_FILE"' EXIT
+
+if grep -RInE 'rm -.*(/tmp/lock/openclash|[$]UPDATE_LOCK)' \
+  "$REPO_ROOT/luci-app-openclash/root/usr/share/openclash" \
+  "$REPO_ROOT/luci-app-openclash/root/etc/init.d/openclash" >"$MATCH_FILE"; then
+  echo "OpenClash flock lock files must not be removed after unlock:" >&2
+  cat "$MATCH_FILE" >&2
+  exit 1
+fi
+
+echo "openclash_flock_lockfile_test.sh: PASS"


### PR DESCRIPTION
## Dependency chain

无依赖，可独立合并。建议与 #5217 都合入后，再继续处理更新后台安装和启动状态类竞态。

## 问题现象

多个 OpenClash helper 在 `flock` 解锁后删除 `/tmp/lock/openclash_*.lock`。在并发请求下，这会让等待者和新进入者分别锁住不同 inode，导致看似有锁、实际双进程同时进入临界区。

## 根因

`flock` 锁定的是打开的文件描述符对应的 inode，而不是路径字符串。流程为：A 持锁，B 已打开同一路径等待旧 inode；A 解锁并删除路径；C 再打开同一路径时创建新 inode 并拿到新锁。此时 B 也可能在旧 inode 上继续执行，互斥失效。

## 证据

受影响路径包括下载/更新、core、dashboard、规则数据、YAML group/proxy 导入导出等 helper。它们共享固定临时文件，例如 `/tmp/openclash.ipk`、`/tmp/clash_meta*.gz`、`/tmp/dash.zip`、`/tmp/yaml_groups.yaml`，锁分裂会放大为文件覆盖或配置写入竞态。

新增 `tests/openclash_flock_lockfile_test.sh` 会扫描 `root/usr/share/openclash` 和 init 脚本，禁止在 `flock` 生命周期后删除 OpenClash 自有锁文件。

## 修复方案

- 保留现有 lock 文件路径和 fd 编号。
- 保留 `flock -u` 解锁行为。
- 移除 `del_lock()` 中删除 OpenClash 自有锁文件的语句，让锁文件作为稳定 inode 留在 `/tmp/lock`。
- 同步覆盖生成的后台安装脚本模板中的安装锁删除。

## 为什么没有扩大范围

本 PR 只修 OpenClash 自有 `flock` 锁文件稳定性，不改变锁粒度、下载目标、重试、安装、YAML 生成顺序或防火墙规则逻辑。系统包管理器锁删除已由 #5217 单独处理；后台安装固定包路径和启动状态判断属于独立问题。

## 与已有开启态 PR 的关系

- #5197 会新增自动更新入口，但仍依赖这些 helper 的互斥语义；本 PR 不修改其功能，只修通用锁基础。
- #5198 和 vernesong/mihomo#10 是 Smart 粘性会话相关，互不相关。
- 已合入的 #5193/#5208/#5209/#5210/#5211 不覆盖 `flock` 锁文件删除导致的 inode 分裂。

## 验证

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`：通过
- `bash -n luci-app-openclash/root/etc/init.d/openclash`：通过
- `bash -n tests/*.sh`：通过
- `for t in tests/*.sh; do bash "$t"; done`：全部通过
- `git diff --check`：通过
- `rg -n '^(<<<<<<<|=======|>>>>>>>)'`：无匹配

未做 live router 写入验证。

## 剩余风险

保留 lock 文件会在 `/tmp/lock` 下留下空文件；这是 `flock` 的正常用法，不代表锁仍被持有。进程异常退出时 fd 会释放锁。
