### PR TITLE
fix: 隔离每轮更新安装包路径

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
@@ -80,6 +80,8 @@ fi
 OP_LV=$(sed -n 1p "$LAST_OPVER" 2>/dev/null |sed "s/^v//g" |tr -d "\n")
 RELEASE_BRANCH=$(uci_get_config "release_branch" || echo "master")
 github_address_mod=$(uci_get_config "github_address_mod" || echo 0)
+UPDATE_PACKAGE_PREFIX="/tmp/openclash_update_$$"
+UPDATE_SCRIPT="/tmp/openclash_update_$$.sh"
 
 #一键更新
 if [ "$1" = "one_key_update" ]; then
@@ -105,27 +107,27 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
       if [ "$github_address_mod" == "https://cdn.jsdelivr.net/" ] || [ "$github_address_mod" == "https://fastly.jsdelivr.net/" ] || [ "$github_address_mod" == "https://testingcf.jsdelivr.net/" ]; then
          if [ -x "/bin/opkg" ]; then
             DOWNLOAD_URL="${github_address_mod}gh/vernesong/OpenClash@package/${RELEASE_BRANCH}/luci-app-openclash_${LAST_VER}_all.ipk"
-            DOWNLOAD_PATH="/tmp/openclash.ipk"
+            DOWNLOAD_PATH="${UPDATE_PACKAGE_PREFIX}.ipk"
          elif [ -x "/usr/bin/apk" ]; then
             DOWNLOAD_URL="${github_address_mod}gh/vernesong/OpenClash@package/${RELEASE_BRANCH}/luci-app-openclash-${LAST_VER}.apk"
-            DOWNLOAD_PATH="/tmp/openclash.apk"
+            DOWNLOAD_PATH="${UPDATE_PACKAGE_PREFIX}.apk"
          fi
       else
          if [ -x "/bin/opkg" ]; then
             DOWNLOAD_URL="${github_address_mod}https://raw.githubusercontent.com/vernesong/OpenClash/package/${RELEASE_BRANCH}/luci-app-openclash_${LAST_VER}_all.ipk"
-            DOWNLOAD_PATH="/tmp/openclash.ipk"
+            DOWNLOAD_PATH="${UPDATE_PACKAGE_PREFIX}.ipk"
          elif [ -x "/usr/bin/apk" ]; then
             DOWNLOAD_URL="${github_address_mod}https://raw.githubusercontent.com/vernesong/OpenClash/package/${RELEASE_BRANCH}/luci-app-openclash-${LAST_VER}.apk"
-            DOWNLOAD_PATH="/tmp/openclash.apk"
+            DOWNLOAD_PATH="${UPDATE_PACKAGE_PREFIX}.apk"
          fi
       fi
    else
       if [ -x "/bin/opkg" ]; then
          DOWNLOAD_URL="https://raw.githubusercontent.com/vernesong/OpenClash/package/${RELEASE_BRANCH}/luci-app-openclash_${LAST_VER}_all.ipk"
-         DOWNLOAD_PATH="/tmp/openclash.ipk"
+         DOWNLOAD_PATH="${UPDATE_PACKAGE_PREFIX}.ipk"
       elif [ -x "/usr/bin/apk" ]; then
          DOWNLOAD_URL="https://raw.githubusercontent.com/vernesong/OpenClash/package/${RELEASE_BRANCH}/luci-app-openclash-${LAST_VER}.apk"
-         DOWNLOAD_PATH="/tmp/openclash.apk"
+         DOWNLOAD_PATH="${UPDATE_PACKAGE_PREFIX}.apk"
       fi
    fi
 
@@ -167,8 +169,8 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
                   LOG_ERROR "【$update_retry/$max_update_retry】【OpenClash - v$LAST_VER】opkg update failed, trying pre update test..."
                fi
             done
-            if [ -s "/tmp/openclash.ipk" ]; then
-               if [ -n "$(opkg install /tmp/openclash.ipk --noaction 2>/dev/null |grep 'Upgrading luci-app-openclash on root' 2>/dev/null)" ]; then
+            if [ -s "$DOWNLOAD_PATH" ]; then
+               if [ -n "$(opkg install "$DOWNLOAD_PATH" --noaction 2>/dev/null |grep 'Upgrading luci-app-openclash on root' 2>/dev/null)" ]; then
                   pre_test_success=true
                fi
             fi
@@ -190,8 +192,8 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
                   LOG_ERROR "【$update_retry/$max_update_retry】【OpenClash - v$LAST_VER】apk update failed, trying pre update test..."
                fi
             done
-            if [ -s "/tmp/openclash.apk" ]; then
-               apk add -s -q --force-overwrite --clean-protected --allow-untrusted /tmp/openclash.apk >/dev/null 2>&1
+            if [ -s "$DOWNLOAD_PATH" ]; then
+               apk add -s -q --force-overwrite --clean-protected --allow-untrusted "$DOWNLOAD_PATH" >/dev/null 2>&1
                if [ $? -eq 0 ]; then
                   pre_test_success=true
                fi
@@ -208,9 +210,9 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
                continue
             else
                if [ -x "/bin/opkg" ]; then
-                  LOG_ERROR "【OpenClash - v$LAST_VER】Pre update test failed after 3 attempts, the file is saved in /tmp/openclash.ipk, please try to update manually with【opkg install /tmp/openclash.ipk】"
+                  LOG_ERROR "【OpenClash - v$LAST_VER】Pre update test failed after 3 attempts, the file is saved in $DOWNLOAD_PATH, please try to update manually with【opkg install $DOWNLOAD_PATH】"
                elif [ -x "/usr/bin/apk" ]; then
-                  LOG_ERROR "【OpenClash - v$LAST_VER】Pre update test failed after 3 attempts, the file is saved in /tmp/openclash.apk, please try to update manually with【apk add -q --force-overwrite --clean-protected --allow-untrusted /tmp/openclash.apk】"
+                  LOG_ERROR "【OpenClash - v$LAST_VER】Pre update test failed after 3 attempts, the file is saved in $DOWNLOAD_PATH, please try to update manually with【apk add -q --force-overwrite --clean-protected --allow-untrusted $DOWNLOAD_PATH】"
                fi
                SLOG_CLEAN
                dec_job_counter_and_restart "0"
@@ -225,8 +227,7 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
             continue
          else
             LOG_ERROR "【OpenClash - v$LAST_VER】Download Failed after 3 attempts, please check the network or try again later!"
-            rm -rf /tmp/openclash.ipk >/dev/null 2>&1
-            rm -rf /tmp/openclash.apk >/dev/null 2>&1
+            rm -rf "$DOWNLOAD_PATH" >/dev/null 2>&1
             dec_job_counter_and_restart "0"
             SLOG_CLEAN
             del_lock
@@ -234,12 +235,13 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
          fi
       fi
    done
-   cat > /tmp/openclash_update.sh <<"EOF"
+   cat > "$UPDATE_SCRIPT" <<"EOF"
 #!/bin/sh
 . /usr/share/openclash/log.sh
 . /usr/share/openclash/openclash_ps.sh
 
 UPDATE_LOCK="/tmp/lock/openclash_update_install.lock"
+PACKAGE_FILE="__OPENCLASH_PACKAGE_FILE__"
 mkdir -p /tmp/lock
 
 set_update_lock() {
@@ -254,6 +256,7 @@ del_update_lock() {
 
 if ! set_update_lock; then
    echo "Update process is already running, exiting..."
+   rm -f "$PACKAGE_FILE" 2>/dev/null
    exit 1
 fi
 
@@ -333,14 +336,14 @@ while [ $install_retry_count -lt $max_install_retries ]; do
             installed_before="$installed_before $pkg"
          fi
       done
-      opkg install /tmp/openclash.ipk
+      opkg install "$PACKAGE_FILE"
    elif [ -x "/usr/bin/apk" ]; then
       for pkg in $packages_to_check; do
          if apk list "$pkg" |grep "installed" >/dev/null 2>&1; then
             installed_before="$installed_before $pkg"
          fi
       done
-      apk add -q --force-overwrite --clean-protected --allow-untrusted /tmp/openclash.apk
+      apk add -q --force-overwrite --clean-protected --allow-untrusted "$PACKAGE_FILE"
    fi
 
    sleep 2
@@ -359,26 +362,27 @@ done
 
 if [ "$install_success" = true ]; then
    if [ -x "/bin/opkg" ]; then
-      rm -rf /tmp/openclash.ipk >/dev/null 2>&1
+      rm -rf "$PACKAGE_FILE" >/dev/null 2>&1
    elif [ -x "/usr/bin/apk" ]; then
-      rm -rf /tmp/openclash.apk >/dev/null 2>&1
+      rm -rf "$PACKAGE_FILE" >/dev/null 2>&1
    fi
 else
    if [ -x "/bin/opkg" ]; then
-      LOG_ERROR "OpenClash update failed after 3 attempts, the file is saved in /tmp/openclash.ipk, please try to update manually with【opkg install /tmp/openclash.ipk】"
+      LOG_ERROR "OpenClash update failed after 3 attempts, the file is saved in $PACKAGE_FILE, please try to update manually with【opkg install $PACKAGE_FILE】"
    elif [ -x "/usr/bin/apk" ]; then
-      LOG_ERROR "OpenClash update failed after 3 attempts, the file is saved in /tmp/openclash.apk, please try to update manually with【apk add -q --force-overwrite --clean-protected --allow-untrusted /tmp/openclash.apk】"
+      LOG_ERROR "OpenClash update failed after 3 attempts, the file is saved in $PACKAGE_FILE, please try to update manually with【apk add -q --force-overwrite --clean-protected --allow-untrusted $PACKAGE_FILE】"
    fi
 fi
 dec_job_counter_and_restart "0"
 SLOG_CLEAN
 del_update_lock
 EOF
-   chmod 4755 /tmp/openclash_update.sh
+   sed -i "s#__OPENCLASH_PACKAGE_FILE__#$DOWNLOAD_PATH#g" "$UPDATE_SCRIPT"
+   chmod 4755 "$UPDATE_SCRIPT"
 
-   if [ ! -f "/tmp/openclash_update.sh" ] || [ ! -s "/tmp/openclash_update.sh" ] || [ ! -x "/tmp/openclash_update.sh" ]; then
+   if [ ! -f "$UPDATE_SCRIPT" ] || [ ! -s "$UPDATE_SCRIPT" ] || [ ! -x "$UPDATE_SCRIPT" ]; then
       LOG_ERROR "Failed to create update script!"
-      rm -rf /tmp/openclash_update.sh
+      rm -rf "$UPDATE_SCRIPT"
       dec_job_counter_and_restart "0"
       SLOG_CLEAN
       del_lock
@@ -393,7 +397,7 @@ EOF
       retry_count=$((retry_count + 1))
       LOG_TIP "【$retry_count/$max_retries】Attempting to start update service..."
 
-      ubus call service add '{"name":"openclash_update","instances":{"update":{"command":["/tmp/openclash_update.sh"],"stdout":true,"stderr":true,"env":{"LAST_VER":"'"$LAST_VER"'"}}}}' >/dev/null 2>&1
+      ubus call service add '{"name":"openclash_update","instances":{"update":{"command":["'"$UPDATE_SCRIPT"'"],"stdout":true,"stderr":true,"env":{"LAST_VER":"'"$LAST_VER"'"}}}}' >/dev/null 2>&1
 
       sleep 3
 
@@ -412,7 +416,7 @@ EOF
       LOG_ERROR "Failed to start update service after 3 attempts, please check and try again later..."
    fi
 
-   (sleep 15; rm -f /tmp/openclash_update.sh) &
+   (sleep 15; rm -f "$UPDATE_SCRIPT") &
 else
    if [ ! -f "$LAST_OPVER" ] || [ -z "$OP_CV" ] || [ -z "$OP_LV" ]; then
       LOG_ERROR "Failed to get version information, please try again later..."

--- a/tests/openclash_update_package_path_test.sh
+++ b/tests/openclash_update_package_path_test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_update.sh"
+
+if grep -nF 'DOWNLOAD_PATH="/tmp/openclash.ipk"' "$SCRIPT" >/dev/null 2>&1 ||
+  grep -nF 'DOWNLOAD_PATH="/tmp/openclash.apk"' "$SCRIPT" >/dev/null 2>&1; then
+  echo "update download path still uses fixed /tmp/openclash package name" >&2
+  exit 1
+fi
+
+if grep -nF 'opkg install /tmp/openclash.ipk' "$SCRIPT" >/dev/null 2>&1 ||
+  grep -nF 'apk add -q --force-overwrite --clean-protected --allow-untrusted /tmp/openclash.apk' "$SCRIPT" >/dev/null 2>&1; then
+  echo "background installer still reads the fixed /tmp/openclash package path" >&2
+  exit 1
+fi
+
+if ! grep -F 'PACKAGE_FILE="__OPENCLASH_PACKAGE_FILE__"' "$SCRIPT" >/dev/null 2>&1; then
+  echo "background installer does not receive the staged package path" >&2
+  exit 1
+fi
+
+if grep -nF '/tmp/openclash_update.sh' "$SCRIPT" >/dev/null 2>&1; then
+  echo "background installer script still uses fixed /tmp/openclash_update.sh path" >&2
+  exit 1
+fi
+
+if ! grep -F 'UPDATE_SCRIPT="/tmp/openclash_update_$$.sh"' "$SCRIPT" >/dev/null 2>&1; then
+  echo "update helper script is not staged per run" >&2
+  exit 1
+fi
+
+echo "openclash_update_package_path_test.sh: PASS"


### PR DESCRIPTION
## Dependency chain

无硬依赖，可独立合并。若与 #5217/#5218 同批处理，建议先合并 #5217 和 #5218，再合并本 PR，便于先稳定锁语义再处理后台安装交接竞态。若 #5197 后续继续修改 `openclash_update.sh`，需要保留本 PR 的 per-run package/helper staging 语义。

## 问题现象

OpenClash 更新父脚本在预检后启动后台安装脚本，但父脚本结束后会释放外层更新锁。后台安装脚本原先读取固定的 `/tmp/openclash.ipk` 或 `/tmp/openclash.apk`，且 helper 脚本也固定为 `/tmp/openclash_update.sh`。此时第二次更新可以进入父脚本，删除或重写第一轮仍在使用的交接文件。

## 根因

下载和安装跨越两个进程：父脚本负责下载和启动 procd 后台服务，后台脚本负责实际 `opkg install` / `apk add`。两者通过固定 `/tmp/openclash.ipk|apk` 和固定 `/tmp/openclash_update.sh` 交接状态，但这些路径不随启动轮次隔离。

## 证据

- 父脚本原先每轮下载到固定 `/tmp/openclash.ipk|apk`。
- 后台安装脚本原先直接安装同一固定包路径。
- 后台 helper 原先固定为 `/tmp/openclash_update.sh`，第一轮延迟清理可能删除第二轮刚生成的 helper。
- 新增 `tests/openclash_update_package_path_test.sh` 禁止固定包路径和固定 helper 路径回归，并要求后台安装脚本接收本轮 staged package 路径。

## 修复方案

- 父脚本下载到 `/tmp/openclash_update_$$.ipk|apk`，每轮进程独立。
- helper 脚本生成到 `/tmp/openclash_update_$$.sh`，ubus command 和延迟清理都使用该路径。
- 生成后台安装脚本时注入本轮 staged package 路径，并让 `opkg install` / `apk add` 读取该路径。
- 如果第二轮后台安装因安装锁已存在而退出，只清理第二轮自己的 staged package，不影响第一轮。
- 安装成功后清理本轮 staged package；安装失败时保留路径并在日志里提示手动安装命令。

## 为什么没有扩大范围

本 PR 不改变下载 URL、代理、重试、安装锁、包管理器调用参数或自动更新返回语义。系统包管理器锁删除由 #5217 处理；OpenClash 自有 `flock` 锁文件稳定性由 #5218 处理。

## 与已有开启态 PR 的关系

- #5197 增加自动更新入口，可能提高触发这个竞态的概率，但没有把后台安装交接文件变为每轮唯一；本 PR 补足这一点。
- #5198 和 vernesong/mihomo#10 是 Smart 粘性会话相关，互不相关。
- 已合入的 #5208/#5210 不覆盖后台安装期间固定交接路径被覆盖的问题。

## 验证

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`：通过
- `bash -n luci-app-openclash/root/etc/init.d/openclash`：通过
- `bash -n tests/*.sh`：通过
- `for t in tests/*.sh; do bash "$t"; done`：全部通过
- `git diff --check`：通过
- `rg -n '^(<<<<<<<|=======|>>>>>>>)'`：无匹配

未做 live router 写入验证。

## 剩余风险

如果后台安装已经进入包管理器内部，仍依赖系统包管理器自身的锁和错误处理；本 PR 只保证 OpenClash 不再通过固定 `/tmp/openclash.ipk|apk` 或固定 `/tmp/openclash_update.sh` 跨轮覆盖安装输入。
