### PR TITLE
fix: 区分核心和 watchdog 运行状态

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -3595,7 +3595,7 @@ start_service()
    enable=$(uci_get_config "enable")
    [ "$enable" != "1" ] && LOG_WARN "OpenClash Now Disabled, Need Start From Luci Page, Exit..." && SLOG_CLEAN && exit 0
 
-   if procd_running "openclash" >/dev/null; then
+   if procd_running "openclash" "openclash" >/dev/null; then
       LOG_TIP "OpenClash Already Running, Exit..."
       exit 0
    fi

--- a/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh
@@ -208,7 +208,7 @@ do
 done >/dev/null 2>&1
 
 #check the clash service status
-if ! ubus call service list '{"name":"openclash"}' 2>/dev/null | jsonfilter -e '@.openclash.instances.*.running' | grep -q 'true'; then
+if ! ubus call service list '{"name":"openclash"}' 2>/dev/null | jsonfilter -e '@.openclash.instances.openclash.running' | grep -q 'true'; then
    uci -q set openclash.config.enable=0
    uci -q commit openclash
    /etc/init.d/openclash stop >/dev/null 2>&1

--- a/tests/openclash_core_instance_state_test.sh
+++ b/tests/openclash_core_instance_state_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INIT_SCRIPT="$REPO_ROOT/luci-app-openclash/root/etc/init.d/openclash"
+WATCHDOG="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh"
+
+if sed -n '/start_service()/,/OpenClash Start Running/p' "$INIT_SCRIPT" | grep -F 'if procd_running "openclash" >/dev/null; then' >/dev/null 2>&1; then
+  echo "start_service still treats any openclash instance as the core process" >&2
+  exit 1
+fi
+
+if ! sed -n '/start_service()/,/OpenClash Start Running/p' "$INIT_SCRIPT" | grep -F 'procd_running "openclash" "openclash"' >/dev/null 2>&1; then
+  echo "start_service does not check the openclash core instance explicitly" >&2
+  exit 1
+fi
+
+if grep -F '@.openclash.instances.*.running' "$WATCHDOG" >/dev/null 2>&1; then
+  echo "watchdog still treats any openclash instance as the core process" >&2
+  exit 1
+fi
+
+if ! grep -F '@.openclash.instances.openclash.running' "$WATCHDOG" >/dev/null 2>&1; then
+  echo "watchdog does not check the openclash core instance explicitly" >&2
+  exit 1
+fi
+
+echo "openclash_core_instance_state_test.sh: PASS"


### PR DESCRIPTION
## Dependency chain

无依赖，可独立合并。建议在继续处理启动 generation guard 前合入，先修正基础运行状态判断。

## 问题现象

OpenClash 的 watchdog 也是 `openclash` 服务下的一个 procd instance。当前 `start_service` 用 `procd_running "openclash"` 判断是否已运行，watchdog 只要还活着，就可能让手动 start 误判为核心已运行。watchdog 自身也用 `instances.*.running` 判断服务状态，可能把自己算作核心存活。

## 根因

core instance 名为 `openclash`，watchdog instance 名为 `openclash-watchdog`。现有判断只看服务任意 instance，而不是明确检查 core instance。

## 证据

- init 脚本中 core 用 `procd_open_instance "openclash"` 启动。
- watchdog 用 `procd_open_instance "openclash-watchdog"` 启动。
- 旧的 `procd_running "openclash"` 和 `instances.*.running` 会把 watchdog 存活误当成 core 存活。
- 新增 `tests/openclash_core_instance_state_test.sh` 覆盖 start 和 watchdog 的 core instance 判断。

## 修复方案

- `start_service` 改为 `procd_running "openclash" "openclash"`，只在 core instance 运行时报告 Already Running。
- watchdog 状态检查改为读取 `@.openclash.instances.openclash.running`，不再把 `openclash-watchdog` 算作 core。

## 为什么没有扩大范围

本 PR 不改变 stop 流程中等待整个服务停止的逻辑，也不改 respawn、PID、TUN/API 检查或防火墙清理。旧后台启动检查反杀新启动的问题需要 generation/PID guard，属于后续独立修复。

## 与已有开启态 PR 的关系

- #5197/#5198 和 vernesong/mihomo#10 不涉及 procd instance 状态判断。
- 已合入的 #5211 只修 watchdog UPNP 动态规则刷新，不覆盖 watchdog/core instance 误判。
- #5217/#5218/#5219 分别处理包管理器锁、自有 flock 锁、更新包路径，互不重复。

## 验证

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`：通过
- `bash -n luci-app-openclash/root/etc/init.d/openclash`：通过
- `bash -n tests/*.sh`：通过
- `for t in tests/*.sh; do bash "$t"; done`：全部通过
- `git diff --check`：通过
- `rg -n '^(<<<<<<<|=======|>>>>>>>)'`：无匹配

未做 live router 写入验证。

## 剩余风险

该修复只解决“watchdog 存活导致核心状态误判”。如果旧的后台启动检查仍在等待并最终失败，仍可能反向停止新启动；这需要单独 generation guard 修复。
