### PR TITLE
fix: 忽略过期启动检查失败

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -27,6 +27,7 @@ CRON_FILE="/etc/crontabs/root"
 CACHE_PATH="/etc/openclash/cache.db"
 LOG_FILE="/tmp/openclash.log"
 START_LOG="/tmp/openclash_start.log"
+START_ID_FILE="/tmp/openclash_start_id"
 PROXY_FWMARK="0x162"
 PROXY_ROUTE_TABLE="0x162"
 QUICK_START_CHECK=false
@@ -325,6 +326,15 @@ EOF
 
 start_fail()
 {
+   local check_start_id="${CHECK_START_ID:-}"
+   local current_start_id
+   if [ -n "$check_start_id" ]; then
+      current_start_id="$(cat "$START_ID_FILE" 2>/dev/null)"
+      if [ "$current_start_id" != "$check_start_id" ]; then
+         LOG_WARN "Skip Stale Core Status Failure..."
+         exit 0
+      fi
+   fi
    uci -q set openclash.config.enable=0
    uci -q commit openclash
    stop
@@ -705,6 +715,7 @@ check_mod()
 
 check_core_status()
 {
+   CHECK_START_ID="$2"
    TUN_WAIT=0
    TUN_RESTART=1
    CORE_WAIT=0
@@ -3600,6 +3611,9 @@ start_service()
       exit 0
    fi
 
+   OPENCLASH_START_ID="$$-$(date +%s)"
+   echo "$OPENCLASH_START_ID" > "$START_ID_FILE"
+
    LOG_TIP "OpenClash Start Running..."
 
    {
@@ -3710,7 +3724,7 @@ start_service()
       add_cron
 
       LOG_OUT "Step 6: Core Status Checking and Firewall Rules Setting..."
-      check_core_status "start" &
+      check_core_status "start" "$OPENCLASH_START_ID" &
 
       if [ "$ipv6_enable" -eq 0 ] && [ "$(uci -q get dhcp.lan.dhcpv6)" != "disabled" ] && [ -n "$(uci -q get dhcp.lan.dhcpv6)" ]; then
          LOG_WARN "Please Note That Network May Abnormal With IPv6's DHCP Server"
@@ -3745,6 +3759,7 @@ stop_service()
          fi
       done
       # prevent respawn during stopping
+      rm -f "$START_ID_FILE"
       procd_kill "openclash"
       for i in $(seq 1 10); do
          procd_running "openclash" >/dev/null && sleep 1 || break

--- a/tests/openclash_start_generation_test.sh
+++ b/tests/openclash_start_generation_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INIT_SCRIPT="$REPO_ROOT/luci-app-openclash/root/etc/init.d/openclash"
+
+if ! grep -F 'START_ID_FILE="/tmp/openclash_start_id"' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "init script does not define a start generation file" >&2
+  exit 1
+fi
+
+if ! grep -F 'OPENCLASH_START_ID="$$-$(date +%s)"' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "start_service does not create a per-start generation id" >&2
+  exit 1
+fi
+
+if ! grep -F 'check_core_status "start" "$OPENCLASH_START_ID" &' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "background core status check does not receive the start generation id" >&2
+  exit 1
+fi
+
+if ! grep -F 'Skip Stale Core Status Failure' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "start_fail does not skip stale background status checks" >&2
+  exit 1
+fi
+
+if ! grep -F 'rm -f "$START_ID_FILE"' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "stop_service does not clear the start generation id" >&2
+  exit 1
+fi
+
+echo "openclash_start_generation_test.sh: PASS"


### PR DESCRIPTION
## Dependency chain

建议在 #5220 之后合并。#5220 先修正 core/watchdog instance 状态判断，本 PR 再处理旧启动检查反向影响新启动的问题。

## 问题现象

`start_service` 会把 `check_core_status "start"` 放到后台等待 core、TUN 或控制接口就绪。如果用户或定时任务在旧检查还没结束时再次 restart，旧检查仍会使用全局 `pidof clash` 和当前网络状态判断。旧检查超时后会调用 `start_fail`，从而把 `openclash.config.enable` 置 0 并 stop 当前服务，可能反向停止已经成功的新一轮启动。

## 根因

后台状态检查没有与启动 generation 绑定。旧检查无法判断自己对应的启动轮次是否已经被新的 start/restart 取代。

## 证据

- `start_service` 原先在 Step 6 后台运行 `check_core_status "start" &`。
- `check_core_status` 超时路径会调用 `start_fail`。
- `start_fail` 会设置 `enable=0` 并执行 `stop`。
- 新增 `tests/openclash_start_generation_test.sh` 覆盖 start generation 文件、后台传参、stale failure 跳过和 stop 清理。

## 修复方案

- 新增 `/tmp/openclash_start_id`，每次 start 生成当前轮次 token。
- 后台 `check_core_status` 接收该 token。
- `start_fail` 在带 token 的后台检查中先确认 token 仍是当前轮次；如果已被新 start/restart 替换，则只记录并退出，不再停用/停止当前服务。
- `stop_service` 清理 generation 文件，让停止期间遗留的后台检查自动变成 stale。

## 为什么没有扩大范围

本 PR 不改变 core 启动命令、respawn、TUN/API 等待条件、防火墙规则或 DNS 设置。没有把所有启动流程串行化，也没有改前台配置失败的处理；只防止旧后台检查影响新一轮服务。

## 与已有开启态 PR 的关系

- #5197/#5198 和 vernesong/mihomo#10 不涉及 init 后台检查 generation。
- #5220 修 core/watchdog instance 误判，本 PR 是后续互补，不重复。
- #5217/#5218/#5219 处理更新和锁文件竞态，互不相关。

## 验证

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`：通过
- `bash -n luci-app-openclash/root/etc/init.d/openclash`：通过
- `bash -n tests/*.sh`：通过
- `for t in tests/*.sh; do bash "$t"; done`：全部通过
- `git diff --check`：通过
- `rg -n '^(<<<<<<<|=======|>>>>>>>)'`：无匹配

未做 live router 写入验证。

## 剩余风险

该 guard 只保护带 generation token 的后台 core 状态检查。手动执行的 firewall/manual/restore 检查仍沿用原先行为，因为它们不是 start/restart 交叠导致的旧轮次问题。
