### PR TITLE
fix: 拒绝复用失败的版本状态

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/clash_version.sh
+++ b/luci-app-openclash/root/usr/share/openclash/clash_version.sh
@@ -44,4 +44,13 @@ else
 fi
 
 DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "$DOWNLOAD_FILE" "$DOWNLOAD_FILE"
+DOWNLOAD_RESULT=$?
+
+if [ "$DOWNLOAD_RESULT" -ne 0 ] && [ "$DOWNLOAD_RESULT" -ne 2 ]; then
+   rm -f "$DOWNLOAD_FILE" >/dev/null 2>&1
+   del_lock
+   exit 1
+fi
+
 del_lock
+exit 0

--- a/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
@@ -45,10 +45,12 @@ RELEASE_BRANCH=$(uci_get_config "release_branch" || echo "master")
 
 if [ "$github_address_mod" != "0" ]; then
    /usr/share/openclash/clash_version.sh "$github_address_mod" 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 else
    /usr/share/openclash/clash_version.sh 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 fi
-if [ ! -f "/tmp/clash_last_version" ]; then
+if [ "$VERSION_CHECK_RESULT" -ne 0 ] || [ ! -f "/tmp/clash_last_version" ]; then
    LOG_ERROR "【"$CORE_TYPE"】Core Version Check Error, Please Try Again Later..."
    SLOG_CLEAN
    del_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
@@ -19,13 +19,16 @@ inc_job_counter
 
 if [ -n "$1" ] && [ "$1" != "one_key_update" ]; then
    /usr/share/openclash/openclash_version.sh "$1" 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 elif [ -n "$2" ]; then
    /usr/share/openclash/openclash_version.sh "$2" 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 else
    /usr/share/openclash/openclash_version.sh 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 fi
 
-if [ ! -f "/tmp/openclash_last_version" ]; then
+if [ "$VERSION_CHECK_RESULT" -ne 0 ] || [ ! -f "/tmp/openclash_last_version" ]; then
    LOG_ERROR "Failed to get version information, please try again later..."
    SLOG_CLEAN
    dec_job_counter_and_restart "0"

--- a/luci-app-openclash/root/usr/share/openclash/openclash_version.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_version.sh
@@ -56,12 +56,18 @@ else
 fi
 
 DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "$DOWNLOAD_FILE" "$DOWNLOAD_FILE"
+DOWNLOAD_RESULT=$?
 
-if [ "$?" -eq 0 ]; then
-   OP_LV=$(sed -n 1p $DOWNLOAD_FILE 2>/dev/null |awk -F 'v' '{print $2}' |awk -F '.' '{print $2$3}' 2>/dev/null)
-   if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ -f "$DOWNLOAD_FILE" ]; then
-      sed -i '/^https:/,$d' $DOWNLOAD_FILE
-   fi
+if [ "$DOWNLOAD_RESULT" -ne 0 ] && [ "$DOWNLOAD_RESULT" -ne 2 ]; then
+   rm -f "$DOWNLOAD_FILE" >/dev/null 2>&1
+   del_lock
+   exit 1
+fi
+
+OP_LV=$(sed -n 1p "$DOWNLOAD_FILE" 2>/dev/null |awk -F 'v' '{print $2}' |awk -F '.' '{print $2$3}' 2>/dev/null)
+if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ -f "$DOWNLOAD_FILE" ]; then
+   sed -i '/^https:/,$d' "$DOWNLOAD_FILE"
 fi
 
 del_lock
+exit 0

--- a/tests/openclash_version_state_test.sh
+++ b/tests/openclash_version_state_test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/openclash-version-state-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/usr/share/openclash" "$WORKDIR/tmp/lock" "$WORKDIR/lib"
+
+cat >"$WORKDIR/usr/share/openclash/openclash_curl.sh" <<'STUB'
+DOWNLOAD_FILE_CURL() {
+   if [ -n "${OPENCLASH_TEST_CURL_COUNT_FILE:-}" ]; then
+      count="$(cat "$OPENCLASH_TEST_CURL_COUNT_FILE" 2>/dev/null || echo 0)"
+      echo $((count + 1)) >"$OPENCLASH_TEST_CURL_COUNT_FILE"
+   fi
+
+   case "${OPENCLASH_TEST_DOWNLOAD_RESULT:-0}" in
+      0)
+         if [ "${OPENCLASH_TEST_VERSION_KIND:-core}" = "package" ]; then
+            printf 'v9.99.9\nhttps://example.invalid/pkg\n' >"$2"
+         else
+            printf 'new-core\nnew-smart\n' >"$2"
+         fi
+         return 0
+      ;;
+      2)
+         return 2
+      ;;
+      *)
+         return 1
+      ;;
+   esac
+}
+STUB
+
+cat >"$WORKDIR/usr/share/openclash/uci.sh" <<'STUB'
+uci_get_config() {
+   return 1
+}
+STUB
+
+cat >"$WORKDIR/usr/share/openclash/log.sh" <<'STUB'
+LOG_ERROR() {
+   printf '%s\n' "$*" >>"${OPENCLASH_TEST_LOG:-/dev/null}"
+}
+LOG_TIP() {
+   printf '%s\n' "$*" >>"${OPENCLASH_TEST_LOG:-/dev/null}"
+}
+SLOG_CLEAN() {
+   :
+}
+STUB
+
+cat >"$WORKDIR/usr/share/openclash/openclash_ps.sh" <<'STUB'
+inc_job_counter() {
+   :
+}
+dec_job_counter_and_restart() {
+   :
+}
+STUB
+
+touch "$WORKDIR/lib/functions.sh"
+
+copy_script() {
+   local src="$1"
+   local dst="$2"
+
+   cp "$REPO_ROOT/$src" "$dst"
+   perl -0pi -e "s#/usr/share/openclash/#$WORKDIR/usr/share/openclash/#g; s#/lib/functions\\.sh#$WORKDIR/lib/functions.sh#g; s#/tmp/lock/#$WORKDIR/tmp/lock/#g; s#/tmp/clash_last_version#$WORKDIR/tmp/clash_last_version#g; s#/tmp/openclash_last_version#$WORKDIR/tmp/openclash_last_version#g" "$dst"
+   chmod +x "$dst"
+}
+
+copy_script "luci-app-openclash/root/usr/share/openclash/clash_version.sh" "$WORKDIR/clash_version.sh"
+copy_script "luci-app-openclash/root/usr/share/openclash/openclash_version.sh" "$WORKDIR/openclash_version.sh"
+cp "$WORKDIR/clash_version.sh" "$WORKDIR/usr/share/openclash/clash_version.sh"
+cp "$WORKDIR/openclash_version.sh" "$WORKDIR/usr/share/openclash/openclash_version.sh"
+copy_script "luci-app-openclash/root/usr/share/openclash/openclash_core.sh" "$WORKDIR/openclash_core.sh"
+copy_script "luci-app-openclash/root/usr/share/openclash/openclash_update.sh" "$WORKDIR/openclash_update.sh"
+
+printf 'stale-core\n' >"$WORKDIR/tmp/clash_last_version"
+if OPENCLASH_TEST_DOWNLOAD_RESULT=1 "$WORKDIR/clash_version.sh"; then
+   echo "expected failed core version check to return non-zero" >&2
+   exit 1
+fi
+[ ! -e "$WORKDIR/tmp/clash_last_version" ] || {
+   echo "failed core version check should not leave stale version state" >&2
+   exit 1
+}
+
+OPENCLASH_TEST_DOWNLOAD_RESULT=0 "$WORKDIR/clash_version.sh"
+[ "$(sed -n 1p "$WORKDIR/tmp/clash_last_version")" = "new-core" ] || {
+   echo "successful core version check did not publish new state" >&2
+   exit 1
+}
+
+printf 'cached-core\n' >"$WORKDIR/tmp/clash_last_version"
+OPENCLASH_TEST_DOWNLOAD_RESULT=2 "$WORKDIR/clash_version.sh"
+[ "$(sed -n 1p "$WORKDIR/tmp/clash_last_version")" = "cached-core" ] || {
+   echo "304 core version check should keep cached state" >&2
+   exit 1
+}
+
+printf 'v1.2.3\nhttps://stale.invalid/pkg\n' >"$WORKDIR/tmp/openclash_last_version"
+if OPENCLASH_TEST_VERSION_KIND=package OPENCLASH_TEST_DOWNLOAD_RESULT=1 "$WORKDIR/openclash_version.sh"; then
+   echo "expected failed package version check to return non-zero" >&2
+   exit 1
+fi
+[ ! -e "$WORKDIR/tmp/openclash_last_version" ] || {
+   echo "failed package version check should not leave stale version state" >&2
+   exit 1
+}
+
+OPENCLASH_TEST_VERSION_KIND=package OPENCLASH_TEST_DOWNLOAD_RESULT=0 "$WORKDIR/openclash_version.sh"
+[ "$(sed -n 1p "$WORKDIR/tmp/openclash_last_version")" = "v9.99.9" ] || {
+   echo "successful package version check did not publish new state" >&2
+   exit 1
+}
+
+printf 'v7.7.7\nhttps://cached.invalid/pkg\n' >"$WORKDIR/tmp/openclash_last_version"
+OPENCLASH_TEST_VERSION_KIND=package OPENCLASH_TEST_DOWNLOAD_RESULT=2 "$WORKDIR/openclash_version.sh"
+[ "$(sed -n 1p "$WORKDIR/tmp/openclash_last_version")" = "v7.7.7" ] || {
+   echo "304 package version check should keep cached state" >&2
+   exit 1
+}
+
+rg -Fq 'VERSION_CHECK_RESULT=$?' "$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_core.sh"
+rg -Fq 'VERSION_CHECK_RESULT=$?' "$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_update.sh"
+
+printf 'v1.2.3\nhttps://stale.invalid/pkg\n' >"$WORKDIR/tmp/openclash_last_version"
+echo 0 >"$WORKDIR/update-count"
+OPENCLASH_TEST_VERSION_KIND=package \
+OPENCLASH_TEST_DOWNLOAD_RESULT=1 \
+OPENCLASH_TEST_CURL_COUNT_FILE="$WORKDIR/update-count" \
+OPENCLASH_TEST_LOG="$WORKDIR/update.log" \
+   "$WORKDIR/openclash_update.sh"
+[ "$(cat "$WORKDIR/update-count")" = "1" ] || {
+   echo "package update caller should stop after failed version refresh" >&2
+   exit 1
+}
+grep -q "Failed to get version information" "$WORKDIR/update.log" || {
+   echo "package update caller did not report failed version refresh" >&2
+   exit 1
+}
+
+printf 'stale-core\n' >"$WORKDIR/tmp/clash_last_version"
+echo 0 >"$WORKDIR/core-count"
+OPENCLASH_TEST_DOWNLOAD_RESULT=1 \
+OPENCLASH_TEST_CURL_COUNT_FILE="$WORKDIR/core-count" \
+OPENCLASH_TEST_LOG="$WORKDIR/core.log" \
+   "$WORKDIR/openclash_core.sh" Meta
+[ "$(cat "$WORKDIR/core-count")" = "1" ] || {
+   echo "core update caller should stop after failed version refresh" >&2
+   exit 1
+}
+grep -q "Core Version Check Error" "$WORKDIR/core.log" || {
+   echo "core update caller did not report failed version refresh" >&2
+   exit 1
+}
+
+echo "openclash_version_state tests passed"


### PR DESCRIPTION
## Dependency chain

推荐合并顺序：本 PR 可独立合并；若同时处理系统包管理器锁状态，请优先或并行合并 #5217。两者触及相邻更新路径，但行为边界不同。

## 问题现象

核心版本检测或 OpenClash 包版本检测失败时，旧的 `/tmp/clash_last_version`、`/tmp/openclash_last_version` 仍会留在本机。随后 `openclash_core.sh` 和 `openclash_update.sh` 只看固定版本文件是否存在，可能把旧版本状态当成本轮检测结果继续进入更新判断。

## 根因

`clash_version.sh` 和 `openclash_version.sh` 调用 `DOWNLOAD_FILE_CURL` 后没有检查返回码，也没有在失败时清理旧版本状态文件。调用方也只判断 fixed last_version 文件是否存在，没有区分“本轮检测成功”和“旧文件还在”。

## 证据

- `clash_version.sh` 原先直接调用 `DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "$DOWNLOAD_FILE" "$DOWNLOAD_FILE"` 后释放锁并退出。
- `openclash_version.sh` 原先只在 `$? -eq 0` 时处理版本内容，失败时旧 `/tmp/openclash_last_version` 仍保留。
- `openclash_core.sh` 原先只判断 `/tmp/clash_last_version` 是否存在。
- `openclash_update.sh` 原先只判断 `/tmp/openclash_last_version` 是否存在。
- `tests/openclash_version_state_test.sh` 覆盖了“已有旧版本文件 + 本轮下载失败”的场景，并验证调用方在版本刷新失败后不会继续进入后续下载路径。

## 修复方案

- 版本检测脚本记录 `DOWNLOAD_FILE_CURL` 返回码。
- 返回 `0` 或 `2` 时按现有成功/304 缓存语义继续。
- 其他失败返回时删除对应 last_version 文件并返回非 0。
- `openclash_core.sh`、`openclash_update.sh` 同时检查版本脚本退出码和 last_version 文件存在性。

## 为什么没有扩大修复范围

没有修改 `openclash_curl.sh` 的通用下载实现，因为它已经使用 `.download.$$` 临时文件避免半截下载覆盖目标。本 PR 只修复调用方对“失败但旧状态仍存在”的判断问题，不改变 ETag、304、CDN、release asset 或系统 feed 行为。

## 与已有开启态 PR 的关系

- #5197 处理自动版本更新入口、配置和调度，不覆盖版本检测失败后旧状态被复用的问题。
- #5217 处理系统包管理器锁状态误删，和本 PR 属于相邻更新路径但行为不同；本 PR 不改 opkg/apk 锁处理。
- #5208 已合入下载失败 HTTP 状态日志，不覆盖调用方对版本刷新返回码的判断。
- #5193、#5209、#5210、#5211 已合入，分别覆盖 dashboard、fw4 DNS guard、核心替换、UPNP 刷新，和本 PR 互不重复。

## 验证命令和结果

均已通过：

```sh
bash -n luci-app-openclash/root/usr/share/openclash/*.sh
bash -n tests/*.sh
tests/openclash_version_state_test.sh
tests/openclash_curl_test.sh
for t in tests/*.sh; do "$t"; done
git diff --check
rg -n '^(<<<<<<<|=======|>>>>>>>)' luci-app-openclash tests
```

最后一条无命中。

## 剩余风险

未做 live router 验证。该修复只改变版本检测失败后的状态处理；如果网络临时失败，UI/更新脚本会要求重新检测版本，而不是继续复用旧 last_version。
