### PR TITLE
fix: 补齐 nat_output DNS 劫持保护

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1351,7 +1351,7 @@ if [ -n "$FW4" ]; then
             nft insert rule inet fw4 dstnat position 0 meta l4proto {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
          fi
       fi
-      if [ "$router_self_proxy" = 1 ]; then
+      if [ "$router_self_proxy" = 1 ] && ! fw4_has_dns_hijack_rule nat_output ipv4; then
          nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
          nft insert rule inet fw4 nat_output position 0 skgid != 65534 meta l4proto {tcp,udp} th dport 53 ip daddr {127.0.0.1} counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
       fi
@@ -1373,7 +1373,7 @@ if [ -n "$FW4" ]; then
          nft add rule inet fw4 openclash_dns_redirect meta l4proto {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
       fi
       nft 'insert rule inet fw4 dstnat position 0 meta l4proto {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
-      if [ "$router_self_proxy" = 1 ]; then
+      if [ "$router_self_proxy" = 1 ] && ! fw4_has_dns_hijack_rule nat_output ipv4; then
          nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
          nft insert rule inet fw4 nat_output position 0 meta l4proto {tcp,udp} th dport 53 ip daddr {127.0.0.1} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
       fi
@@ -1696,8 +1696,8 @@ if [ -n "$FW4" ]; then
          fi
       fi
 
-      if ! fw4_has_dns_hijack_rule dstnat ipv6; then
-         if [ "$enable_redirect_dns" -eq 1 ]; then
+      if [ "$enable_redirect_dns" -eq 1 ]; then
+         if ! fw4_has_dns_hijack_rule dstnat ipv6; then
             if [ "$lan_ac_mode" != "1" ]; then
                ACBLACKDNSFILTER=""
                if [ "$lan_ac_mode" = "0" ]; then
@@ -1713,11 +1713,13 @@ if [ -n "$FW4" ]; then
                nft insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 saddr @lan_ac_white_ipv6s counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
                nft insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
             fi
-            if [ "$router_self_proxy" = 1 ]; then
-               nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
-               nft insert rule inet fw4 nat_output position 0 skgid != 65534 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
-            fi
-         elif [ "$enable_redirect_dns" -eq 2 ]; then
+         fi
+         if [ "$router_self_proxy" = 1 ] && ! fw4_has_dns_hijack_rule nat_output ipv6; then
+            nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
+            nft insert rule inet fw4 nat_output position 0 skgid != 65534 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
+         fi
+      elif [ "$enable_redirect_dns" -eq 2 ]; then
+         if ! fw4_has_dns_hijack_rule dstnat ipv6; then
             if [ "$lan_ac_mode" != "1" ]; then
                ACBLACKDNSFILTER=""
                if [ "$lan_ac_mode" = "0" ]; then
@@ -1734,10 +1736,10 @@ if [ -n "$FW4" ]; then
                nft add rule inet fw4 openclash_dns_redirect meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
             fi
             nft 'insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
-            if [ "$router_self_proxy" = 1 ]; then
-               nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
-               nft insert rule inet fw4 nat_output position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
-            fi
+         fi
+         if [ "$router_self_proxy" = 1 ] && ! fw4_has_dns_hijack_rule nat_output ipv6; then
+            nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
+            nft insert rule inet fw4 nat_output position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
          fi
       fi
 

--- a/tests/fw4_dns_hijack_guard_test.sh
+++ b/tests/fw4_dns_hijack_guard_test.sh
@@ -64,4 +64,39 @@ assert_status 0 fw4_has_dns_hijack_rule dstnat ipv6
 assert_status 1 fw4_has_dns_hijack_rule nat_output ipv4
 assert_status 0 fw4_has_dns_hijack_rule nat_output ipv6
 
+assert_nat_output_insert_guarded() {
+  family="$1"
+  insert_text="$2"
+
+  awk -v family="$family" -v insert_text="$insert_text" '
+    $0 ~ "fw4_has_dns_hijack_rule nat_output " family {
+      guard_window = 5
+    }
+    $0 ~ "nft insert rule inet fw4 nat_output" && index($0, insert_text) && $0 ~ "OpenClash DNS Hijack" {
+      seen++
+      if (guard_window <= 0) {
+        print "nat_output DNS insert is not guarded for " family ": " $0 > "/dev/stderr"
+        bad = 1
+      }
+    }
+    {
+      if (guard_window > 0) {
+        guard_window--
+      }
+    }
+    END {
+      if (seen != 2) {
+        print "expected two guarded nat_output DNS inserts for " family ", got " seen > "/dev/stderr"
+        exit 1
+      }
+      if (bad) {
+        exit 1
+      }
+    }
+  ' "$INIT_SCRIPT"
+}
+
+assert_nat_output_insert_guarded ipv4 'ip daddr {127.0.0.1}'
+assert_nat_output_insert_guarded ipv6 'ip6 daddr {::/0}'
+
 echo "fw4_dns_hijack_guard_test.sh: PASS"


### PR DESCRIPTION
## Dependency chain

推荐合并顺序：本 PR 建议在已合入的 #5209 之后评审。#5209 提供了按 chain/family 区分的 `fw4_has_dns_hijack_rule`，本 PR 只把这个能力用于仍未保护的 `nat_output` DNS 劫持调用点。

## 问题现象

在 fw4 + `router_self_proxy=1` 场景下，OpenClash restore/start 路径可能重复插入本机 `nat_output` DNS 劫持规则；如果 IPv6 `dstnat` 规则存在但 `nat_output` 规则缺失，当前代码也不会补回 IPv6 本机 DNS 劫持。

## 根因

#5209 已让 helper 能区分 `dstnat` / `nat_output` 和 IPv4 / IPv6，但调用点仍存在两个问题：

- IPv4 `nat_output` 插入不检查 `nat_output ipv4` 是否已存在。
- IPv6 `nat_output` 插入被包在 `dstnat ipv6` guard 内，`dstnat` 已存在时会跳过整段，导致缺失的 `nat_output` 不能自愈。

## 证据

- IPv4 `enable_redirect_dns=1` 和 `enable_redirect_dns=2` 都会在 `router_self_proxy=1` 时插入 `nat_output` DNS 规则。
- IPv6 原逻辑只在 `! fw4_has_dns_hijack_rule dstnat ipv6` 成立时才进入 `nat_output` 插入。
- `reload "restore"` 可不经过完整 firewall revert 直接重设部分规则，因此调用点需要自身幂等。
- `tests/fw4_dns_hijack_guard_test.sh` 现有 helper 用例只能证明 helper 可区分 chain/family；本 PR 增加调用点检查，确保真实 `nat_output` DNS 插入前存在同 family guard。

## 修复方案

- IPv4 两条 `nat_output` DNS 插入前增加 `! fw4_has_dns_hijack_rule nat_output ipv4`。
- IPv6 把 `nat_output` DNS 插入从 `dstnat ipv6` guard 内拆出，并单独使用 `! fw4_has_dns_hijack_rule nat_output ipv6`。
- 保留原有 `dstnat`、`openclash_dns_redirect`、iptables/fw3 分支和 DNS redirect 语义。

## 为什么没有扩大修复范围

没有在本 PR 中重构 `enable_redirect_dns=2` 的 `openclash_dns_redirect` 链刷新，也没有修改 fw3/iptables 路径。redirect chain 的重复规则和 jump 幂等属于另一个行为边界，需要单独评估 flush/guard 策略，避免把 DNS 转发语义和本机代理 DNS 劫持混在一个补丁里。

## 与已有开启态 PR 的关系

- #5209 已合入，覆盖 helper 的 chain/family 区分，但没有覆盖本 PR 修复的 `nat_output` 调用点。
- #5220、#5221 分别处理 procd instance 状态和启动检查代际，不覆盖 firewall `nat_output` 幂等。
- #5217、#5218、#5219、#5222 都在更新/锁/版本状态路径，和本 PR 互不重复。
- #5197、#5198 是功能 PR，不覆盖本问题。

## 验证命令和结果

均已通过：

```sh
bash -n luci-app-openclash/root/usr/share/openclash/*.sh
bash -n luci-app-openclash/root/etc/init.d/openclash
bash -n tests/*.sh
tests/fw4_dns_hijack_guard_test.sh
for t in tests/*.sh; do "$t"; done
git diff --check
rg -n '^(<<<<<<<|=======|>>>>>>>)' luci-app-openclash/root/etc/init.d/openclash tests/fw4_dns_hijack_guard_test.sh
```

最后一条无命中。

## 剩余风险

未做 live router 验证。本 PR 不改变已有规则的端口或目标，如果用户在 restore 路径中同时切换 DNS redirect 模式/端口，仍依赖完整 firewall revert 或后续 redirect chain 幂等修复来刷新旧规则。
