### PR TITLE
fix: 中断时恢复旧控制面板

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/openclash_download_dashboard.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_download_dashboard.sh
@@ -56,6 +56,13 @@ EOF
       [ -d "$OLD_FILE_DIR" ] && mv "$OLD_FILE_DIR" "$TARGET_FILE_DIR" >/dev/null 2>&1
    }
 
+   handle_dashboard_signal() {
+      [ "${DASHBOARD_REPLACE_STARTED:-0}" = "1" ] && restore_old_dashboard
+      cleanup_dashboard_tmp
+      del_lock
+      exit 130
+   }
+
    log_unzip_error() {
       LOG_OUT "Control Panel【$DASH_NAME - $DASH_TYPE】Unzip Error!" && SLOG_CLEAN
       cleanup_dashboard_tmp
@@ -101,6 +108,8 @@ EOF
    TARGET_PARENT_DIR="$(dirname "$TARGET_FILE_DIR")"
    NEW_FILE_DIR="${TARGET_PARENT_DIR}/.openclash_dashboard_new.$$"
    OLD_FILE_DIR="${TARGET_PARENT_DIR}/.openclash_dashboard_old.$$"
+   DASHBOARD_REPLACE_STARTED=0
+   trap 'handle_dashboard_signal' HUP INT TERM
 
    DOWNLOAD_FILE_CURL "$DOWNLOAD_PATH" "$DASH_FILE_DIR" "$UNPACK_FILE_DIR"
    DOWNLOAD_RESULT=$?
@@ -117,9 +126,11 @@ EOF
 
             mkdir -p "$TARGET_PARENT_DIR" >/dev/null 2>&1 || log_unzip_error
             if [ -d "$TARGET_FILE_DIR" ]; then
+               DASHBOARD_REPLACE_STARTED=1
                mv "$TARGET_FILE_DIR" "$OLD_FILE_DIR" >/dev/null 2>&1 || log_unzip_error
             fi
             if mv "$NEW_FILE_DIR" "$TARGET_FILE_DIR" >/dev/null 2>&1 && validate_dashboard_dir "$TARGET_FILE_DIR"; then
+               DASHBOARD_REPLACE_STARTED=0
                cleanup_dashboard_tmp
                LOG_OUT "Control Panel【$DASH_NAME - $DASH_TYPE】Download Successful!" && SLOG_CLEAN
                del_lock

--- a/tests/openclash_download_dashboard_test.sh
+++ b/tests/openclash_download_dashboard_test.sh
@@ -50,6 +50,21 @@ exit 0
 STUB
 chmod +x "$WORKDIR/bin/flock"
 
+cat >"$WORKDIR/bin/mv" <<'STUB'
+#!/usr/bin/env sh
+/bin/mv "$@"
+status=$?
+if [ "$status" -eq 0 ] && [ "${TEST_KILL_AFTER_OLD_MOVE:-0}" = "1" ]; then
+  case "${2:-}" in
+    *.openclash_dashboard_old.*)
+      kill -TERM "$PPID"
+      ;;
+  esac
+fi
+exit "$status"
+STUB
+chmod +x "$WORKDIR/bin/mv"
+
 cp "$SCRIPT_UNDER_TEST" "$WORKDIR/openclash_download_dashboard.sh"
 perl -0pi -e "s#/usr/share/openclash/#$WORKDIR/usr/share/openclash/#g; s#/lib/functions\\.sh#$WORKDIR/lib/functions.sh#g; s#/tmp/dash\\.zip#$WORKDIR/tmp/dash.zip#g; s#/tmp/dash/#$WORKDIR/tmp/dash/#g; s#/tmp/lock/#$WORKDIR/tmp/lock/#g" "$WORKDIR/openclash_download_dashboard.sh"
 chmod +x "$WORKDIR/openclash_download_dashboard.sh"
@@ -311,6 +326,35 @@ test_staging_dirs_are_under_target_parent() {
   fi
 }
 
+test_term_after_old_move_restores_existing_dashboard() {
+  local ui_dir="$WORKDIR/usr/share/openclash/ui/zashboard"
+  local good_zip="$WORKDIR/signal-zashboard.zip"
+  rm -rf "$WORKDIR/usr/share/openclash/ui"
+  mkdir -p "$ui_dir/assets"
+  printf '<script src="./assets/app.js"></script>\nold-good\n' >"$ui_dir/index.html"
+  printf 'old-js\n' >"$ui_dir/assets/app.js"
+  make_dashboard_zip "$good_zip" "zashboard-gh-pages-cdn-fonts" "yes"
+  TEST_LOG="$WORKDIR/signal.log"
+  : >"$TEST_LOG"
+
+  set +e
+  TEST_LOG="$TEST_LOG" TEST_DOWNLOAD_RESULT=0 TEST_ZIP="$good_zip" TEST_KILL_AFTER_OLD_MOVE=1 PATH="$WORKDIR/bin:$PATH" \
+    "$WORKDIR/openclash_download_dashboard.sh" Zashboard Official
+  local status=$?
+  set -e
+
+  if [ "$status" -ne 130 ]; then
+    echo "expected dashboard update interrupted after old move to exit 130, got $status" >&2
+    exit 1
+  fi
+  assert_file_exists "$ui_dir/index.html"
+  assert_file_contains "$ui_dir/index.html" "old-good"
+  if find "$WORKDIR/usr/share/openclash/ui" -maxdepth 1 -name '.openclash_dashboard_*' | grep -q .; then
+    echo "expected dashboard staging directories to be cleaned after signal" >&2
+    exit 1
+  fi
+}
+
 test_304_requires_existing_dashboard_entrypoint
 test_bad_zip_preserves_existing_dashboard
 test_good_zip_installs_dashboard
@@ -320,5 +364,6 @@ test_single_quoted_missing_asset_preserves_existing_dashboard
 test_one_line_missing_stylesheet_preserves_existing_dashboard
 test_index_without_local_script_preserves_existing_dashboard
 test_staging_dirs_are_under_target_parent
+test_term_after_old_move_restores_existing_dashboard
 
 echo "openclash_download_dashboard tests passed"


### PR DESCRIPTION
## Dependency chain

推荐合并顺序：本 PR 基于已合入的 #5193。#5193 已解决 dashboard 下载校验、staging 安装和失败回滚；本 PR 只补信号中断窗口。

## 问题现象

控制面板更新时，如果进程在旧目录已移动到 `.openclash_dashboard_old.$$`、新目录尚未完成落位和校验之间收到 `HUP` / `INT` / `TERM`，目标 dashboard 目录可能暂时或永久缺失，只留下隐藏旧目录或 staging 目录。

## 根因

#5193 的普通失败路径会调用 `restore_old_dashboard`，但脚本没有 signal trap。外部中断不会走普通错误分支，因而不会恢复旧 dashboard 或清理 staging 目录。

## 证据

- `openclash_download_dashboard.sh` 先把现有 `TARGET_FILE_DIR` 移到 `.openclash_dashboard_old.$$`，随后再把 `.openclash_dashboard_new.$$` 移回目标目录。
- 普通失败路径有 rollback，但 `HUP` / `INT` / `TERM` 不会进入该路径。
- 新增测试用受控 `mv` wrapper 在旧目录移动成功后发送 `TERM`，验证脚本返回中断状态、旧 `index.html` 被恢复、`.openclash_dashboard_*` staging 目录被清理。

## 修复方案

- 增加 `DASHBOARD_REPLACE_STARTED` 标志，只在旧目录替换窗口开启后允许恢复旧 dashboard。
- 为 `HUP` / `INT` / `TERM` 增加 trap：恢复旧目录、清理临时文件、释放锁并退出。
- 成功安装并校验新目录后清零恢复标志，避免已经验证的新面板被误回滚。

## 为什么没有扩大修复范围

没有修改 #5193 已合入的目录完整性校验、304 复验、staging 路径或下载逻辑。trap 早于替换窗口不会删除目标目录；只有确认旧目录已进入 `.old.$$` 窗口后才尝试恢复。

## 与已有开启态 PR 的关系

- #5193 已合入，覆盖 dashboard 校验和普通失败回滚；本 PR 只补 signal 中断恢复窗口。
- #5208 已合入，覆盖下载失败 HTTP 状态日志，和本 PR 无重叠。
- #5217、#5218、#5219、#5220、#5221、#5222、#5223 分别处理锁、更新、运行状态、版本状态、fw4 `nat_output` 等路径，不覆盖本问题。
- #5197、#5198 是功能 PR，不覆盖本问题。

## 验证命令和结果

均已通过：

```sh
bash -n luci-app-openclash/root/usr/share/openclash/*.sh
bash -n tests/*.sh
tests/openclash_download_dashboard_test.sh
for t in tests/*.sh; do "$t"; done
git diff --check
rg -n '^(<<<<<<<|=======|>>>>>>>)' luci-app-openclash/root/usr/share/openclash/openclash_download_dashboard.sh tests/openclash_download_dashboard_test.sh
```

最后一条无命中。

## 剩余风险

未做 live router 验证。该补丁只处理脚本进程收到常见终止信号的情况；断电、内核级强制 kill 等无法由 shell trap 恢复。
