### PR TITLE
fix: 串行化启动停止生命周期

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -323,10 +323,23 @@ EOF
 
 } >/dev/null 2>&1
 
+set_lifecycle_lock()
+{
+   mkdir -p /tmp/lock 2>/dev/null
+   exec 867>"/tmp/lock/openclash_lifecycle.lock" 2>/dev/null
+   flock -x 867 2>/dev/null
+}
+
+del_lifecycle_lock()
+{
+   flock -u 867 2>/dev/null
+}
+
 start_fail()
 {
    uci -q set openclash.config.enable=0
    uci -q commit openclash
+   del_lifecycle_lock
    stop
    exit 0
 }
@@ -3595,8 +3608,11 @@ start_service()
    enable=$(uci_get_config "enable")
    [ "$enable" != "1" ] && LOG_WARN "OpenClash Now Disabled, Need Start From Luci Page, Exit..." && SLOG_CLEAN && exit 0
 
+   set_lifecycle_lock
+
    if procd_running "openclash" >/dev/null; then
       LOG_TIP "OpenClash Already Running, Exit..."
+      del_lifecycle_lock
       exit 0
    fi
 
@@ -3719,11 +3735,14 @@ start_service()
       rm -rf /tmp/yaml_*
    }
 
+   del_lifecycle_lock
    echo "OpenClash Already Start!"
 }
 
 stop_service()
 {
+   set_lifecycle_lock
+
    get_config
 
    LOG_TIP "OpenClash Stoping..."
@@ -3778,6 +3797,7 @@ stop_service()
       rm -rf /tmp/yaml_*
    } >/dev/null 2>&1
 
+   del_lifecycle_lock
    echo "OpenClash Already Stop!"
 }
 

--- a/tests/openclash_lifecycle_lock_test.sh
+++ b/tests/openclash_lifecycle_lock_test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INIT_SCRIPT="$REPO_ROOT/luci-app-openclash/root/etc/init.d/openclash"
+
+require_pattern() {
+  local pattern="$1"
+  local message="$2"
+
+  if ! PATTERN="$pattern" perl -0ne 'exit(/$ENV{PATTERN}/s ? 0 : 1)' "$INIT_SCRIPT"; then
+    echo "$message" >&2
+    exit 1
+  fi
+}
+
+require_pattern 'set_lifecycle_lock\(\).*?openclash_lifecycle\.lock.*?flock -x 867' \
+  "lifecycle lock setup is missing or does not use a stable flock file"
+
+require_pattern 'del_lifecycle_lock\(\).*?flock -u 867' \
+  "lifecycle lock release is missing"
+
+if grep -F 'rm -rf "/tmp/lock/openclash_lifecycle.lock"' "$INIT_SCRIPT" >/dev/null 2>&1 ||
+   grep -F "rm -rf '/tmp/lock/openclash_lifecycle.lock'" "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "lifecycle lock file should not be removed while other waiters may hold it" >&2
+  exit 1
+fi
+
+require_pattern 'start_fail\(\).*?del_lifecycle_lock.*?stop' \
+  "start_fail should release lifecycle lock before re-entering stop"
+
+require_pattern 'start_service\(\).*?set_lifecycle_lock.*?procd_running "openclash".*?del_lifecycle_lock.*?exit 0.*?rm -rf /tmp/yaml_\*.*?del_lifecycle_lock' \
+  "start_service should hold lifecycle lock through yaml cleanup and release it on already-running exit"
+
+require_pattern 'stop_service\(\).*?set_lifecycle_lock.*?get_config.*?rm -rf /tmp/yaml_\*.*?del_lifecycle_lock' \
+  "stop_service should hold lifecycle lock through yaml cleanup"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/openclash-lifecycle-lock-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/bin" "$WORKDIR/tmp/lock" "$WORKDIR/flock-state"
+
+cat >"$WORKDIR/bin/flock" <<'STUB'
+#!/usr/bin/env sh
+mode="$1"
+case "$mode" in
+  -x)
+    while ! mkdir "${TEST_FLOCK_STATE:?}/held" 2>/dev/null; do
+      sleep 0.05
+    done
+  ;;
+  -u)
+    rmdir "${TEST_FLOCK_STATE:?}/held" 2>/dev/null || true
+  ;;
+  *)
+    echo "unexpected flock mode: $*" >&2
+    exit 1
+  ;;
+esac
+STUB
+chmod +x "$WORKDIR/bin/flock"
+
+awk '
+  /^set_lifecycle_lock\(\)/ { print_block=1 }
+  /^del_lifecycle_lock\(\)/ { print_block=1 }
+  print_block { print }
+  /^}/ && print_block { print_block=0 }
+' "$INIT_SCRIPT" >"$WORKDIR/lifecycle.sh"
+PERL_WORKDIR="$WORKDIR" perl -0pi -e 's#/tmp/lock#$ENV{PERL_WORKDIR}/tmp/lock#g' "$WORKDIR/lifecycle.sh"
+
+cat >"$WORKDIR/lock_worker.sh" <<'STUB'
+#!/usr/bin/env sh
+. "$TEST_LIFECYCLE_FUNCS"
+
+case "$1" in
+  first)
+    set_lifecycle_lock
+    echo "first-held" >>"$TEST_LOCK_LOG"
+    : >"$TEST_FIRST_HELD"
+    while [ ! -f "$TEST_RELEASE_FIRST" ]; do
+      sleep 0.05
+    done
+    del_lifecycle_lock
+    echo "first-released" >>"$TEST_LOCK_LOG"
+  ;;
+  second)
+    echo "second-waiting" >>"$TEST_LOCK_LOG"
+    set_lifecycle_lock
+    echo "second-held" >>"$TEST_LOCK_LOG"
+    del_lifecycle_lock
+  ;;
+  *)
+    exit 1
+  ;;
+esac
+STUB
+chmod +x "$WORKDIR/lock_worker.sh"
+
+TEST_LOCK_LOG="$WORKDIR/lock.log"
+TEST_FIRST_HELD="$WORKDIR/first-held"
+TEST_RELEASE_FIRST="$WORKDIR/release-first"
+: >"$TEST_LOCK_LOG"
+
+env TEST_LIFECYCLE_FUNCS="$WORKDIR/lifecycle.sh" \
+    TEST_FLOCK_STATE="$WORKDIR/flock-state" \
+    TEST_LOCK_LOG="$TEST_LOCK_LOG" \
+    TEST_FIRST_HELD="$TEST_FIRST_HELD" \
+    TEST_RELEASE_FIRST="$TEST_RELEASE_FIRST" \
+    PATH="$WORKDIR/bin:$PATH" \
+    "$WORKDIR/lock_worker.sh" first &
+first_pid=$!
+
+while [ ! -f "$TEST_FIRST_HELD" ]; do
+  sleep 0.05
+done
+
+env TEST_LIFECYCLE_FUNCS="$WORKDIR/lifecycle.sh" \
+    TEST_FLOCK_STATE="$WORKDIR/flock-state" \
+    TEST_LOCK_LOG="$TEST_LOCK_LOG" \
+    TEST_FIRST_HELD="$TEST_FIRST_HELD" \
+    TEST_RELEASE_FIRST="$TEST_RELEASE_FIRST" \
+    PATH="$WORKDIR/bin:$PATH" \
+    "$WORKDIR/lock_worker.sh" second &
+second_pid=$!
+
+sleep 0.2
+if grep -q '^second-held$' "$TEST_LOCK_LOG"; then
+  echo "second lifecycle holder entered before first released the lock" >&2
+  exit 1
+fi
+
+: >"$TEST_RELEASE_FIRST"
+wait "$first_pid"
+wait "$second_pid"
+
+grep -q '^first-released$' "$TEST_LOCK_LOG" || {
+  echo "first lifecycle holder did not release the lock" >&2
+  exit 1
+}
+grep -q '^second-held$' "$TEST_LOCK_LOG" || {
+  echo "second lifecycle holder did not acquire the lock after release" >&2
+  exit 1
+}
+
+echo "openclash_lifecycle_lock_test.sh: PASS"


### PR DESCRIPTION
## Dependency chain

推荐合并顺序：本 PR 可独立评审；若同时处理启动检查代际问题，建议先合并 #5221，再合并本 PR。#5221 处理旧后台启动检查反杀新启动，本 PR 处理 start/stop 生命周期和 `/tmp/yaml_*` 临时状态串行化，两者互补不替代。

## 问题现象

启动生成 runtime YAML 时，OpenClash core 尚未注册为 running。此时另一个 start/restart/stop 可以进入同一生命周期路径，复用固定 `/tmp/${CFG_NAME}` 和 `/tmp/yaml_*` 临时文件，导致一轮启动清理或覆盖另一轮尚未消费的 YAML 中间状态。

## 根因

`start_service` 只用 `procd_running "openclash"` 判断 core 是否已运行，但 Step 3 生成 YAML 时 core 还没有启动。与此同时，`yml_change.sh`、overwrite 生成脚本和 init cleanup 都使用固定 `/tmp/yaml_*` 文件名；`stop_service` 也会在尾部清理 `/tmp/yaml_*`。

## 证据

- `get_config` 将 `TMP_CONFIG_FILE` 设为 `/tmp/${CFG_NAME}`，不是按启动轮次隔离。
- `start_service` 在 Step 3 调用 `yml_change.sh`、`yml_rules_change.sh` 和 overwrite 脚本，并在尾部 `rm -rf /tmp/yaml_*`。
- `stop_service` 同样在尾部 `rm -rf /tmp/yaml_*`。
- #5218 只覆盖 OpenClash helper 自有 flock 文件稳定性；#5221 只覆盖旧后台 `check_core_status` 的代际问题，均不串行化这段生命周期。

## 修复方案

- 增加 `openclash_lifecycle.lock`，用稳定锁文件串行化 `start_service` 和 `stop_service` 主体。
- 不删除 lifecycle lock 文件，避免等待者和持有者看到不同 inode。
- `start_fail` 在调用 `stop` 前释放 lifecycle lock，避免同一进程错误路径重入 stop 时自锁。
- `start_service` 在启动 core、设置后台状态检查并清理 `/tmp/yaml_*` 后释放锁；不把锁持有到后台 `check_core_status` 阶段。

## 为什么没有扩大修复范围

没有把所有 YAML helper 改成 per-run 目录，也没有调整 `yml_change.sh` / `yml_rules_change.sh` / overwrite 的顺序。这样保留现有非 OIX 和手动 overwrite 语义，只先消除 start/stop 对固定 YAML 临时状态的并发互踩。

`flock` 不是本 PR 新增的运行时依赖：当前 OpenClash 多个脚本已经使用相同模式的 `flock`。测试环境不假设本机有系统 `flock`，而是用可控 stub 模拟排他语义验证本 PR 的锁/释放时序。

## 与已有开启态 PR 的关系

- #5218 覆盖 helper 自有 flock 锁文件被删除导致的锁分裂，不覆盖 init 生命周期串行化。
- #5221 覆盖旧后台启动检查失败误停新启动，不覆盖 `/tmp/yaml_*` 生成/清理互踩。
- #5220 覆盖 procd instance running 状态，不覆盖 core 尚未启动前的 YAML 生成窗口。
- #5217、#5219、#5222、#5223、#5224 分别处理包管理器锁、更新包路径、版本状态、fw4 `nat_output`、dashboard signal，和本 PR 互不重复。
- #5197、#5198 是功能 PR，不覆盖本问题。

## 验证命令和结果

均已通过：

```sh
bash -n luci-app-openclash/root/usr/share/openclash/*.sh
bash -n luci-app-openclash/root/etc/init.d/openclash
bash -n tests/*.sh
tests/openclash_lifecycle_lock_test.sh
for t in tests/*.sh; do "$t"; done
git diff --check HEAD~1..HEAD
rg -n '^(<<<<<<<|=======|>>>>>>>)' luci-app-openclash/root/etc/init.d/openclash tests/openclash_lifecycle_lock_test.sh
```

最后一条无命中。

## 剩余风险

未做 live router 验证。该补丁串行化 start/stop 主体，连续 restart 可能等待前一轮 YAML 生成完成；这是刻意选择的行为，用等待换取避免固定 `/tmp/yaml_*` 状态互踩。后台 `check_core_status` 不持有 lifecycle lock，避免与失败路径 stop 互锁。
