### PR TITLE
fix: 避免重复 DNS redirect 跳转

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -932,6 +932,20 @@ fw4_has_dns_hijack_rule()
    esac
 }
 
+fw4_has_dns_redirect_jump()
+{
+   local family="$1"
+
+   case "$family" in
+      ipv6)
+         nft list chain inet fw4 dstnat 2>/dev/null |grep 'jump openclash_dns_redirect' |grep -Eq 'meta nfproto[[:space:]]+\{?ipv6\}?|meta nfproto[[:space:]]+ipv6|ip6 nexthdr'
+      ;;
+      *)
+         nft list chain inet fw4 dstnat 2>/dev/null |grep 'jump openclash_dns_redirect' |grep -Evq 'meta nfproto[[:space:]]+\{?ipv6\}?|meta nfproto[[:space:]]+ipv6|ip6 nexthdr'
+      ;;
+   esac
+}
+
 firewall_lan_ac_traffic()
 {
    local src_port sport_rule dscp_rule sport_ipt dscp_ipt src_ip src_ip_v6 proto target target_ enabled family dscp rule output_rule comment
@@ -1357,6 +1371,7 @@ if [ -n "$FW4" ]; then
       fi
    elif [ "$enable_redirect_dns" -eq 2 ]; then
       nft 'add chain inet fw4 openclash_dns_redirect'
+      nft 'flush chain inet fw4 openclash_dns_redirect'
       if [ "$lan_ac_mode" != "1" ]; then
          ACBLACKDNSFILTER=""
          if [ "$lan_ac_mode" = "0" ]; then
@@ -1372,7 +1387,9 @@ if [ -n "$FW4" ]; then
          nft add rule inet fw4 openclash_dns_redirect meta l4proto {tcp,udp} th dport 53 ip saddr @lan_ac_white_ips counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
          nft add rule inet fw4 openclash_dns_redirect meta l4proto {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
       fi
-      nft 'insert rule inet fw4 dstnat position 0 meta l4proto {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
+      if ! fw4_has_dns_redirect_jump ipv4; then
+         nft 'insert rule inet fw4 dstnat position 0 meta l4proto {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
+      fi
       if [ "$router_self_proxy" = 1 ]; then
          nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
          nft insert rule inet fw4 nat_output position 0 meta l4proto {tcp,udp} th dport 53 ip daddr {127.0.0.1} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
@@ -1733,7 +1750,9 @@ if [ -n "$FW4" ]; then
                nft add rule inet fw4 openclash_dns_redirect meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 saddr @lan_ac_white_ipv6s counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
                nft add rule inet fw4 openclash_dns_redirect meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
             fi
-            nft 'insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
+            if ! fw4_has_dns_redirect_jump ipv6; then
+               nft 'insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
+            fi
             if [ "$router_self_proxy" = 1 ]; then
                nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
                nft insert rule inet fw4 nat_output position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"

--- a/tests/fw4_dns_hijack_guard_test.sh
+++ b/tests/fw4_dns_hijack_guard_test.sh
@@ -13,6 +13,13 @@ if [ -z "$fn" ]; then
 fi
 eval "$fn"
 
+redirect_fn=$(awk '/^fw4_has_dns_redirect_jump\(\)/,/^}/' "$INIT_SCRIPT")
+if [ -z "$redirect_fn" ]; then
+  echo "fw4_has_dns_redirect_jump not found" >&2
+  exit 1
+fi
+eval "$redirect_fn"
+
 cat >"$WORKDIR/nft" <<'STUB'
 #!/usr/bin/env sh
 if [ "$*" = "list chain inet fw4 dstnat" ]; then
@@ -51,6 +58,18 @@ assert_status 0 fw4_has_dns_hijack_rule dstnat ipv4
 assert_status 1 fw4_has_dns_hijack_rule dstnat ipv6
 assert_status 0 fw4_has_dns_hijack_rule nat_output ipv4
 assert_status 1 fw4_has_dns_hijack_rule nat_output ipv6
+assert_status 1 fw4_has_dns_redirect_jump ipv4
+assert_status 1 fw4_has_dns_redirect_jump ipv6
+
+cat >"$TEST_NFT_DSTNAT" <<'EOF'
+meta l4proto { tcp, udp } th dport 53 counter jump openclash_dns_redirect
+meta nfproto ipv6 ip6 nexthdr { tcp, udp } th dport 53 counter jump openclash_dns_redirect
+EOF
+cat >"$TEST_NFT_NAT_OUTPUT" <<'EOF'
+EOF
+
+assert_status 0 fw4_has_dns_redirect_jump ipv4
+assert_status 0 fw4_has_dns_redirect_jump ipv6
 
 cat >"$TEST_NFT_DSTNAT" <<'EOF'
 meta nfproto ipv6 ip6 nexthdr { tcp, udp } th dport 53 counter redirect to :53 comment "OpenClash DNS Hijack"
@@ -63,5 +82,45 @@ assert_status 1 fw4_has_dns_hijack_rule dstnat ipv4
 assert_status 0 fw4_has_dns_hijack_rule dstnat ipv6
 assert_status 1 fw4_has_dns_hijack_rule nat_output ipv4
 assert_status 0 fw4_has_dns_hijack_rule nat_output ipv6
+
+if ! grep -F "flush chain inet fw4 openclash_dns_redirect" "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "openclash_dns_redirect chain should be flushed before rebuilding redirect rules" >&2
+  exit 1
+fi
+
+assert_redirect_jump_guarded() {
+  family="$1"
+  jump_text="$2"
+
+  awk -v family="$family" -v jump_text="$jump_text" '
+    $0 ~ "fw4_has_dns_redirect_jump " family {
+      guard_window = 4
+    }
+    index($0, jump_text) {
+      seen++
+      if (guard_window <= 0) {
+        print "redirect jump is not guarded for " family ": " $0 > "/dev/stderr"
+        bad = 1
+      }
+    }
+    {
+      if (guard_window > 0) {
+        guard_window--
+      }
+    }
+    END {
+      if (seen != 1) {
+        print "expected one guarded redirect jump for " family ", got " seen > "/dev/stderr"
+        exit 1
+      }
+      if (bad) {
+        exit 1
+      }
+    }
+  ' "$INIT_SCRIPT"
+}
+
+assert_redirect_jump_guarded ipv4 'nft '\''insert rule inet fw4 dstnat position 0 meta l4proto {tcp,udp} th dport 53 counter jump openclash_dns_redirect'\'''
+assert_redirect_jump_guarded ipv6 'nft '\''insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 counter jump openclash_dns_redirect'\'''
 
 echo "fw4_dns_hijack_guard_test.sh: PASS"


### PR DESCRIPTION
## Dependency chain

推荐合并顺序：#5223 和本 PR 都改 `luci-app-openclash/root/etc/init.d/openclash` 的 fw4 DNS 区域，建议先合并 #5223，再合并本 PR 并按需解决文本冲突。语义组合方式是：同时保留 #5223 的 `nat_output` guard 和本 PR 的 `openclash_dns_redirect` chain / jump 幂等。

## 问题现象

fw4 + `enable_redirect_dns=2` 场景下，restore/start 重入会重复追加 `openclash_dns_redirect` 链内规则和 `dstnat -> openclash_dns_redirect` jump。时间长了会造成 nft 规则堆叠，日志和排障也会被重复规则干扰。

## 根因

#5209 已解决 direct DNS hijack 规则的 IPv4/IPv6 识别，但 `enable_redirect_dns=2` 的 jump 规则没有 `OpenClash DNS Hijack` comment，也没有独立 guard；`openclash_dns_redirect` 链每次 add rule 前也没有 flush，因此 restore 重入会累积规则。

## 证据

- IPv4 `enable_redirect_dns=2` 分支每次都会向 `openclash_dns_redirect` add 规则，并无条件向 `dstnat` insert jump。
- IPv6 `enable_redirect_dns=2` 分支同样无条件 insert IPv6 jump。
- `reload "restore"` 路径会调用 `do_run_mode` 和 `check_core_status`，不一定先完整 revert firewall，因此调用点需要自身幂等。
- `tests/fw4_dns_hijack_guard_test.sh` 覆盖了 IPv4/IPv6 jump 识别，并用结构断言确认真实 jump 插入在对应 `fw4_has_dns_redirect_jump` guard 下。

## 修复方案

- 新增 `fw4_has_dns_redirect_jump`，按 IPv4/IPv6 识别 `dstnat -> openclash_dns_redirect` jump。
- `enable_redirect_dns=2` 重建前 flush `openclash_dns_redirect` 链，避免链内 redirect 规则堆叠。
- IPv4/IPv6 jump 插入前分别检查已有 jump，缺失时才插入。

## 为什么没有扩大修复范围

没有修改 fw3/iptables 分支，没有改 direct DNS hijack 规则，也没有处理 `nat_output` DNS 幂等；后者由 #5223 单独处理。本 PR 只覆盖 `enable_redirect_dns=2` 的 redirect chain 和 dstnat jump。

## 与已有开启态 PR 的关系

- #5223 处理 `nat_output` DNS 劫持 guard，和本 PR同区相邻但行为不同；两者可能有文本冲突，语义上应组合。
- #5209 已合入，覆盖 direct DNS hijack helper 的 chain/family 区分，但不覆盖 redirect jump。
- #5220、#5221、#5225 处理启动/状态路径，不覆盖 fw4 redirect chain。
- #5217、#5218、#5219、#5222、#5224 处理锁、更新、版本和 dashboard 路径，和本 PR 互不重复。

## 验证命令和结果

均已通过：

```sh
bash -n luci-app-openclash/root/usr/share/openclash/*.sh
bash -n luci-app-openclash/root/etc/init.d/openclash
bash -n tests/*.sh
tests/fw4_dns_hijack_guard_test.sh
for t in tests/*.sh; do "$t"; done
git diff --check
rg -n '^(<<<<<<<|=======|>>>>>>>)' luci-app-openclash/root/etc/init.d/openclash tests/fw4_dns_hijack_guard_test.sh
```

最后一条无命中。

## 剩余风险

未做 live router 验证。该补丁会在 `enable_redirect_dns=2` 时刷新 `openclash_dns_redirect` 链内容；如果用户在运行中切换 DNS redirect 端口或 LAN access 规则，下一次 restore 会以当前 UCI 状态重建该链。
