### PR TITLE
fix: 合并 fw4 DNS 劫持幂等修复

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -932,6 +932,20 @@ fw4_has_dns_hijack_rule()
    esac
 }
 
+fw4_has_dns_redirect_jump()
+{
+   local family="$1"
+
+   case "$family" in
+      ipv6)
+         nft list chain inet fw4 dstnat 2>/dev/null |grep 'jump openclash_dns_redirect' |grep -Eq 'meta nfproto[[:space:]]+\{?ipv6\}?|meta nfproto[[:space:]]+ipv6|ip6 nexthdr'
+      ;;
+      *)
+         nft list chain inet fw4 dstnat 2>/dev/null |grep 'jump openclash_dns_redirect' |grep -Evq 'meta nfproto[[:space:]]+\{?ipv6\}?|meta nfproto[[:space:]]+ipv6|ip6 nexthdr'
+      ;;
+   esac
+}
+
 firewall_lan_ac_traffic()
 {
    local src_port sport_rule dscp_rule sport_ipt dscp_ipt src_ip src_ip_v6 proto target target_ enabled family dscp rule output_rule comment
@@ -1351,12 +1365,13 @@ if [ -n "$FW4" ]; then
             nft insert rule inet fw4 dstnat position 0 meta l4proto {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
          fi
       fi
-      if [ "$router_self_proxy" = 1 ]; then
+      if [ "$router_self_proxy" = 1 ] && ! fw4_has_dns_hijack_rule nat_output ipv4; then
          nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
          nft insert rule inet fw4 nat_output position 0 skgid != 65534 meta l4proto {tcp,udp} th dport 53 ip daddr {127.0.0.1} counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
       fi
    elif [ "$enable_redirect_dns" -eq 2 ]; then
       nft 'add chain inet fw4 openclash_dns_redirect'
+      nft 'flush chain inet fw4 openclash_dns_redirect'
       if [ "$lan_ac_mode" != "1" ]; then
          ACBLACKDNSFILTER=""
          if [ "$lan_ac_mode" = "0" ]; then
@@ -1372,8 +1387,10 @@ if [ -n "$FW4" ]; then
          nft add rule inet fw4 openclash_dns_redirect meta l4proto {tcp,udp} th dport 53 ip saddr @lan_ac_white_ips counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
          nft add rule inet fw4 openclash_dns_redirect meta l4proto {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
       fi
-      nft 'insert rule inet fw4 dstnat position 0 meta l4proto {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
-      if [ "$router_self_proxy" = 1 ]; then
+      if ! fw4_has_dns_redirect_jump ipv4; then
+         nft 'insert rule inet fw4 dstnat position 0 meta l4proto {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
+      fi
+      if [ "$router_self_proxy" = 1 ] && ! fw4_has_dns_hijack_rule nat_output ipv4; then
          nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
          nft insert rule inet fw4 nat_output position 0 meta l4proto {tcp,udp} th dport 53 ip daddr {127.0.0.1} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
       fi
@@ -1696,8 +1713,8 @@ if [ -n "$FW4" ]; then
          fi
       fi
 
-      if ! fw4_has_dns_hijack_rule dstnat ipv6; then
-         if [ "$enable_redirect_dns" -eq 1 ]; then
+      if [ "$enable_redirect_dns" -eq 1 ]; then
+         if ! fw4_has_dns_hijack_rule dstnat ipv6; then
             if [ "$lan_ac_mode" != "1" ]; then
                ACBLACKDNSFILTER=""
                if [ "$lan_ac_mode" = "0" ]; then
@@ -1713,31 +1730,33 @@ if [ -n "$FW4" ]; then
                nft insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 saddr @lan_ac_white_ipv6s counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
                nft insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
             fi
-            if [ "$router_self_proxy" = 1 ]; then
-               nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
-               nft insert rule inet fw4 nat_output position 0 skgid != 65534 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
-            fi
-         elif [ "$enable_redirect_dns" -eq 2 ]; then
-            if [ "$lan_ac_mode" != "1" ]; then
-               ACBLACKDNSFILTER=""
-               if [ "$lan_ac_mode" = "0" ]; then
-                  if [ -n "$(uci_get_config "lan_ac_black_ips")" ]; then
-                     ACBLACKDNSFILTER="ip6 saddr != @lan_ac_black_ipv6s"
-                  fi
-                  if [ -n "$(uci_get_config "lan_ac_black_macs")" ]; then
-                     ACBLACKDNSFILTER="$ACBLACKDNSFILTER ether saddr != @lan_ac_black_macs"
-                  fi
+         fi
+         if [ "$router_self_proxy" = 1 ] && ! fw4_has_dns_hijack_rule nat_output ipv6; then
+            nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
+            nft insert rule inet fw4 nat_output position 0 skgid != 65534 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
+         fi
+      elif [ "$enable_redirect_dns" -eq 2 ]; then
+         if [ "$lan_ac_mode" != "1" ]; then
+            ACBLACKDNSFILTER=""
+            if [ "$lan_ac_mode" = "0" ]; then
+               if [ -n "$(uci_get_config "lan_ac_black_ips")" ]; then
+                  ACBLACKDNSFILTER="ip6 saddr != @lan_ac_black_ipv6s"
                fi
-               nft add rule inet fw4 openclash_dns_redirect meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ${ACBLACKDNSFILTER} counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
-            else
-               nft add rule inet fw4 openclash_dns_redirect meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 saddr @lan_ac_white_ipv6s counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
-               nft add rule inet fw4 openclash_dns_redirect meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
+               if [ -n "$(uci_get_config "lan_ac_black_macs")" ]; then
+                  ACBLACKDNSFILTER="$ACBLACKDNSFILTER ether saddr != @lan_ac_black_macs"
+               fi
             fi
+            nft add rule inet fw4 openclash_dns_redirect meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ${ACBLACKDNSFILTER} counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
+         else
+            nft add rule inet fw4 openclash_dns_redirect meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 saddr @lan_ac_white_ipv6s counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
+            nft add rule inet fw4 openclash_dns_redirect meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ether saddr @lan_ac_white_macs counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
+         fi
+         if ! fw4_has_dns_redirect_jump ipv6; then
             nft 'insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
-            if [ "$router_self_proxy" = 1 ]; then
-               nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
-               nft insert rule inet fw4 nat_output position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
-            fi
+         fi
+         if [ "$router_self_proxy" = 1 ] && ! fw4_has_dns_hijack_rule nat_output ipv6; then
+            nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
+            nft insert rule inet fw4 nat_output position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
          fi
       fi
 

--- a/tests/fw4_dns_hijack_guard_test.sh
+++ b/tests/fw4_dns_hijack_guard_test.sh
@@ -13,6 +13,13 @@ if [ -z "$fn" ]; then
 fi
 eval "$fn"
 
+redirect_fn=$(awk '/^fw4_has_dns_redirect_jump\(\)/,/^}/' "$INIT_SCRIPT")
+if [ -z "$redirect_fn" ]; then
+  echo "fw4_has_dns_redirect_jump not found" >&2
+  exit 1
+fi
+eval "$redirect_fn"
+
 cat >"$WORKDIR/nft" <<'STUB'
 #!/usr/bin/env sh
 if [ "$*" = "list chain inet fw4 dstnat" ]; then
@@ -51,6 +58,18 @@ assert_status 0 fw4_has_dns_hijack_rule dstnat ipv4
 assert_status 1 fw4_has_dns_hijack_rule dstnat ipv6
 assert_status 0 fw4_has_dns_hijack_rule nat_output ipv4
 assert_status 1 fw4_has_dns_hijack_rule nat_output ipv6
+assert_status 1 fw4_has_dns_redirect_jump ipv4
+assert_status 1 fw4_has_dns_redirect_jump ipv6
+
+cat >"$TEST_NFT_DSTNAT" <<'EOF'
+meta l4proto { tcp, udp } th dport 53 counter jump openclash_dns_redirect
+meta nfproto ipv6 ip6 nexthdr { tcp, udp } th dport 53 counter jump openclash_dns_redirect
+EOF
+cat >"$TEST_NFT_NAT_OUTPUT" <<'EOF'
+EOF
+
+assert_status 0 fw4_has_dns_redirect_jump ipv4
+assert_status 0 fw4_has_dns_redirect_jump ipv6
 
 cat >"$TEST_NFT_DSTNAT" <<'EOF'
 meta nfproto ipv6 ip6 nexthdr { tcp, udp } th dport 53 counter redirect to :53 comment "OpenClash DNS Hijack"
@@ -63,5 +82,116 @@ assert_status 1 fw4_has_dns_hijack_rule dstnat ipv4
 assert_status 0 fw4_has_dns_hijack_rule dstnat ipv6
 assert_status 1 fw4_has_dns_hijack_rule nat_output ipv4
 assert_status 0 fw4_has_dns_hijack_rule nat_output ipv6
+
+assert_nat_output_insert_guarded() {
+  family="$1"
+  insert_text="$2"
+
+  awk -v family="$family" -v insert_text="$insert_text" '
+    $0 ~ "fw4_has_dns_hijack_rule nat_output " family {
+      guard_window = 5
+    }
+    $0 ~ "nft insert rule inet fw4 nat_output" && index($0, insert_text) && $0 ~ "OpenClash DNS Hijack" {
+      seen++
+      if (guard_window <= 0) {
+        print "nat_output DNS insert is not guarded for " family ": " $0 > "/dev/stderr"
+        bad = 1
+      }
+    }
+    {
+      if (guard_window > 0) {
+        guard_window--
+      }
+    }
+    END {
+      if (seen != 2) {
+        print "expected two guarded nat_output DNS inserts for " family ", got " seen > "/dev/stderr"
+        exit 1
+      }
+      if (bad) {
+        exit 1
+      }
+    }
+  ' "$INIT_SCRIPT"
+}
+
+if ! grep -F "flush chain inet fw4 openclash_dns_redirect" "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "openclash_dns_redirect chain should be flushed before rebuilding redirect rules" >&2
+  exit 1
+fi
+
+assert_redirect_jump_guarded() {
+  family="$1"
+  jump_text="$2"
+
+  awk -v family="$family" -v jump_text="$jump_text" '
+    $0 ~ "fw4_has_dns_redirect_jump " family {
+      guard_window = 4
+    }
+    index($0, jump_text) {
+      seen++
+      if (guard_window <= 0) {
+        print "redirect jump is not guarded for " family ": " $0 > "/dev/stderr"
+        bad = 1
+      }
+    }
+    {
+      if (guard_window > 0) {
+        guard_window--
+      }
+    }
+    END {
+      if (seen != 1) {
+        print "expected one guarded redirect jump for " family ", got " seen > "/dev/stderr"
+        exit 1
+      }
+      if (bad) {
+        exit 1
+      }
+    }
+  ' "$INIT_SCRIPT"
+}
+
+assert_ipv6_redirect_rebuild_not_guarded_by_direct_hijack() {
+  awk '
+    $0 ~ /\[ "\$enable_redirect_dns" -eq 2 \]/ {
+      in_redirect = 1
+      depth = 1
+      next
+    }
+    in_redirect {
+      if ($0 ~ /fw4_has_dns_hijack_rule dstnat ipv6/) {
+        print "IPv6 redirect-chain rebuild must not be guarded by direct dstnat hijack state" > "/dev/stderr"
+        bad = 1
+      }
+      if ($0 ~ /nft add rule inet fw4 openclash_dns_redirect meta nfproto \{ipv6\}/) {
+        seen_redirect_rule = 1
+      }
+      if ($0 ~ /fw4_has_dns_redirect_jump ipv6/) {
+        seen_jump_guard = 1
+      }
+      if ($0 ~ /^[[:space:]]*if /) {
+        depth++
+      }
+      if ($0 ~ /^[[:space:]]*fi$/) {
+        depth--
+        if (depth == 0) {
+          in_redirect = 0
+        }
+      }
+    }
+    END {
+      if (!seen_redirect_rule || !seen_jump_guard || bad) {
+        exit 1
+      }
+    }
+  ' "$INIT_SCRIPT"
+}
+
+assert_nat_output_insert_guarded ipv4 'ip daddr {127.0.0.1}'
+assert_nat_output_insert_guarded ipv6 'ip6 daddr {::/0}'
+assert_redirect_jump_guarded ipv4 'nft '\''insert rule inet fw4 dstnat position 0 meta l4proto {tcp,udp} th dport 53 counter jump openclash_dns_redirect'\'''
+assert_redirect_jump_guarded ipv6 'nft '\''insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 counter jump openclash_dns_redirect'\'''
+assert_ipv6_redirect_rebuild_not_guarded_by_direct_hijack
 
 echo "fw4_dns_hijack_guard_test.sh: PASS"


### PR DESCRIPTION
## 变更

合并两个原本拆开的 fw4 DNS 幂等修复：

- 取代 #5223：按 IPv4/IPv6 独立 guard `nat_output` DNS 劫持规则，避免重复插入，也避免 `dstnat` 已存在时漏补本机 DNS 劫持。
- 取代 #5226：`enable_redirect_dns=2` 每次重建 `openclash_dns_redirect` 前先 flush，并按 IPv4/IPv6 guard `dstnat -> openclash_dns_redirect` jump。

这两个拆分 PR 会在 `luci-app-openclash/root/etc/init.d/openclash` 和 `tests/fw4_dns_hijack_guard_test.sh` 上产生真实合并冲突；合并成一个 PR 后，审核者只需要审查一组完整的 fw4 DNS 幂等语义。

## 根因

原拆分虽然行为边界清楚，但审核与合并不友好：

- `nat_output` DNS 劫持是否存在，不能由 `dstnat` 状态推断。
- redirect 模式的 chain 内容需要重建，但 jump 本身需要去重。

## 验证

- `bash tests/fw4_dns_hijack_guard_test.sh`
- `sh -n luci-app-openclash/root/etc/init.d/openclash`
- `git diff --check origin/dev...HEAD`
- `rg '^(<<<<<<<|=======|>>>>>>>)' luci-app-openclash tests`
- 多轮对抗式复核，最终无修改点
