### PR TITLE
fix: 合并 OpenClash 启停生命周期竞态修复

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -27,6 +27,7 @@ CRON_FILE="/etc/crontabs/root"
 CACHE_PATH="/etc/openclash/cache.db"
 LOG_FILE="/tmp/openclash.log"
 START_LOG="/tmp/openclash_start.log"
+START_ID_FILE="/tmp/openclash_start_id"
 PROXY_FWMARK="0x162"
 PROXY_ROUTE_TABLE="0x162"
 QUICK_START_CHECK=false
@@ -323,10 +324,32 @@ EOF
 
 } >/dev/null 2>&1
 
+set_lifecycle_lock()
+{
+   mkdir -p /tmp/lock 2>/dev/null
+   exec 867>"/tmp/lock/openclash_lifecycle.lock" 2>/dev/null
+   flock -x 867 2>/dev/null
+}
+
+del_lifecycle_lock()
+{
+   flock -u 867 2>/dev/null
+}
+
 start_fail()
 {
+   local check_start_id="${CHECK_START_ID:-}"
+   local current_start_id
+   if [ -n "$check_start_id" ]; then
+      current_start_id="$(cat "$START_ID_FILE" 2>/dev/null)"
+      if [ "$current_start_id" != "$check_start_id" ]; then
+         LOG_WARN "Skip Stale Core Status Failure..."
+         exit 0
+      fi
+   fi
    uci -q set openclash.config.enable=0
    uci -q commit openclash
+   del_lifecycle_lock
    stop
    exit 0
 }
@@ -705,6 +728,7 @@ check_mod()
 
 check_core_status()
 {
+   CHECK_START_ID="$2"
    TUN_WAIT=0
    TUN_RESTART=1
    CORE_WAIT=0
@@ -3595,9 +3619,19 @@ start_service()
    enable=$(uci_get_config "enable")
    [ "$enable" != "1" ] && LOG_WARN "OpenClash Now Disabled, Need Start From Luci Page, Exit..." && SLOG_CLEAN && exit 0
 
-   if procd_running "openclash" >/dev/null; then
+   set_lifecycle_lock
+
+   if procd_running "openclash" "openclash" >/dev/null; then
       LOG_TIP "OpenClash Already Running, Exit..."
+      del_lifecycle_lock
       exit 0
+   fi
+
+   OPENCLASH_START_ID="$$-$(date +%s)"
+   if ! echo "$OPENCLASH_START_ID" > "$START_ID_FILE"; then
+      LOG_WARN "Write OpenClash Start State Failed, Exit..."
+      del_lifecycle_lock
+      exit 1
    fi
 
    LOG_TIP "OpenClash Start Running..."
@@ -3710,7 +3744,10 @@ start_service()
       add_cron
 
       LOG_OUT "Step 6: Core Status Checking and Firewall Rules Setting..."
-      check_core_status "start" &
+      (
+         exec 867>&- 2>/dev/null
+         check_core_status "start" "$OPENCLASH_START_ID"
+      ) &
 
       if [ "$ipv6_enable" -eq 0 ] && [ "$(uci -q get dhcp.lan.dhcpv6)" != "disabled" ] && [ -n "$(uci -q get dhcp.lan.dhcpv6)" ]; then
          LOG_WARN "Please Note That Network May Abnormal With IPv6's DHCP Server"
@@ -3719,11 +3756,15 @@ start_service()
       rm -rf /tmp/yaml_*
    }
 
+   del_lifecycle_lock
    echo "OpenClash Already Start!"
 }
 
 stop_service()
 {
+   set_lifecycle_lock
+   rm -f "$START_ID_FILE"
+
    get_config
 
    LOG_TIP "OpenClash Stoping..."
@@ -3778,6 +3819,7 @@ stop_service()
       rm -rf /tmp/yaml_*
    } >/dev/null 2>&1
 
+   del_lifecycle_lock
    echo "OpenClash Already Stop!"
 }
 

--- a/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh
@@ -208,7 +208,7 @@ do
 done >/dev/null 2>&1
 
 #check the clash service status
-if ! ubus call service list '{"name":"openclash"}' 2>/dev/null | jsonfilter -e '@.openclash.instances.*.running' | grep -q 'true'; then
+if ! ubus call service list '{"name":"openclash"}' 2>/dev/null | jsonfilter -e '@.openclash.instances.openclash.running' | grep -q 'true'; then
    uci -q set openclash.config.enable=0
    uci -q commit openclash
    /etc/init.d/openclash stop >/dev/null 2>&1

--- a/tests/openclash_core_instance_state_test.sh
+++ b/tests/openclash_core_instance_state_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INIT_SCRIPT="$REPO_ROOT/luci-app-openclash/root/etc/init.d/openclash"
+WATCHDOG="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh"
+
+if sed -n '/start_service()/,/OpenClash Start Running/p' "$INIT_SCRIPT" | grep -F 'if procd_running "openclash" >/dev/null; then' >/dev/null 2>&1; then
+  echo "start_service still treats any openclash instance as the core process" >&2
+  exit 1
+fi
+
+if ! sed -n '/start_service()/,/OpenClash Start Running/p' "$INIT_SCRIPT" | grep -F 'procd_running "openclash" "openclash"' >/dev/null 2>&1; then
+  echo "start_service does not check the openclash core instance explicitly" >&2
+  exit 1
+fi
+
+if grep -F '@.openclash.instances.*.running' "$WATCHDOG" >/dev/null 2>&1; then
+  echo "watchdog still treats any openclash instance as the core process" >&2
+  exit 1
+fi
+
+if ! grep -F '@.openclash.instances.openclash.running' "$WATCHDOG" >/dev/null 2>&1; then
+  echo "watchdog does not check the openclash core instance explicitly" >&2
+  exit 1
+fi
+
+echo "openclash_core_instance_state_test.sh: PASS"

--- a/tests/openclash_lifecycle_lock_test.sh
+++ b/tests/openclash_lifecycle_lock_test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INIT_SCRIPT="$REPO_ROOT/luci-app-openclash/root/etc/init.d/openclash"
+
+require_pattern() {
+  local pattern="$1"
+  local message="$2"
+
+  if ! PATTERN="$pattern" perl -0ne 'exit(/$ENV{PATTERN}/s ? 0 : 1)' "$INIT_SCRIPT"; then
+    echo "$message" >&2
+    exit 1
+  fi
+}
+
+require_pattern 'set_lifecycle_lock\(\).*?openclash_lifecycle\.lock.*?flock -x 867' \
+  "lifecycle lock setup is missing or does not use a stable flock file"
+
+require_pattern 'del_lifecycle_lock\(\).*?flock -u 867' \
+  "lifecycle lock release is missing"
+
+if grep -F 'rm -rf "/tmp/lock/openclash_lifecycle.lock"' "$INIT_SCRIPT" >/dev/null 2>&1 ||
+   grep -F "rm -rf '/tmp/lock/openclash_lifecycle.lock'" "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "lifecycle lock file should not be removed while other waiters may hold it" >&2
+  exit 1
+fi
+
+require_pattern 'start_fail\(\).*?del_lifecycle_lock.*?stop' \
+  "start_fail should release lifecycle lock before re-entering stop"
+
+require_pattern 'start_service\(\).*?set_lifecycle_lock.*?procd_running "openclash".*?del_lifecycle_lock.*?exit 0.*?rm -rf /tmp/yaml_\*.*?del_lifecycle_lock' \
+  "start_service should hold lifecycle lock through yaml cleanup and release it on already-running exit"
+
+require_pattern 'start_service\(\).*?exec 867>&- 2>/dev/null.*?check_core_status "start" "\$OPENCLASH_START_ID".*?\) &' \
+  "background core status check should close inherited lifecycle lock fd before it can call start_fail"
+
+require_pattern 'stop_service\(\).*?set_lifecycle_lock.*?get_config.*?rm -rf /tmp/yaml_\*.*?del_lifecycle_lock' \
+  "stop_service should hold lifecycle lock through yaml cleanup"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/openclash-lifecycle-lock-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/bin" "$WORKDIR/tmp/lock" "$WORKDIR/flock-state"
+
+cat >"$WORKDIR/bin/flock" <<'STUB'
+#!/usr/bin/env sh
+mode="$1"
+case "$mode" in
+  -x)
+    while ! mkdir "${TEST_FLOCK_STATE:?}/held" 2>/dev/null; do
+      sleep 0.05
+    done
+  ;;
+  -u)
+    rmdir "${TEST_FLOCK_STATE:?}/held" 2>/dev/null || true
+  ;;
+  *)
+    echo "unexpected flock mode: $*" >&2
+    exit 1
+  ;;
+esac
+STUB
+chmod +x "$WORKDIR/bin/flock"
+
+awk '
+  /^set_lifecycle_lock\(\)/ { print_block=1 }
+  /^del_lifecycle_lock\(\)/ { print_block=1 }
+  print_block { print }
+  /^}/ && print_block { print_block=0 }
+' "$INIT_SCRIPT" >"$WORKDIR/lifecycle.sh"
+PERL_WORKDIR="$WORKDIR" perl -0pi -e 's#/tmp/lock#$ENV{PERL_WORKDIR}/tmp/lock#g' "$WORKDIR/lifecycle.sh"
+
+cat >"$WORKDIR/lock_worker.sh" <<'STUB'
+#!/usr/bin/env sh
+. "$TEST_LIFECYCLE_FUNCS"
+
+case "$1" in
+  first)
+    set_lifecycle_lock
+    echo "first-held" >>"$TEST_LOCK_LOG"
+    : >"$TEST_FIRST_HELD"
+    while [ ! -f "$TEST_RELEASE_FIRST" ]; do
+      sleep 0.05
+    done
+    del_lifecycle_lock
+    echo "first-released" >>"$TEST_LOCK_LOG"
+  ;;
+  second)
+    echo "second-waiting" >>"$TEST_LOCK_LOG"
+    set_lifecycle_lock
+    echo "second-held" >>"$TEST_LOCK_LOG"
+    del_lifecycle_lock
+  ;;
+  *)
+    exit 1
+  ;;
+esac
+STUB
+chmod +x "$WORKDIR/lock_worker.sh"
+
+TEST_LOCK_LOG="$WORKDIR/lock.log"
+TEST_FIRST_HELD="$WORKDIR/first-held"
+TEST_RELEASE_FIRST="$WORKDIR/release-first"
+: >"$TEST_LOCK_LOG"
+
+env TEST_LIFECYCLE_FUNCS="$WORKDIR/lifecycle.sh" \
+    TEST_FLOCK_STATE="$WORKDIR/flock-state" \
+    TEST_LOCK_LOG="$TEST_LOCK_LOG" \
+    TEST_FIRST_HELD="$TEST_FIRST_HELD" \
+    TEST_RELEASE_FIRST="$TEST_RELEASE_FIRST" \
+    PATH="$WORKDIR/bin:$PATH" \
+    "$WORKDIR/lock_worker.sh" first &
+first_pid=$!
+
+while [ ! -f "$TEST_FIRST_HELD" ]; do
+  sleep 0.05
+done
+
+env TEST_LIFECYCLE_FUNCS="$WORKDIR/lifecycle.sh" \
+    TEST_FLOCK_STATE="$WORKDIR/flock-state" \
+    TEST_LOCK_LOG="$TEST_LOCK_LOG" \
+    TEST_FIRST_HELD="$TEST_FIRST_HELD" \
+    TEST_RELEASE_FIRST="$TEST_RELEASE_FIRST" \
+    PATH="$WORKDIR/bin:$PATH" \
+    "$WORKDIR/lock_worker.sh" second &
+second_pid=$!
+
+sleep 0.2
+if grep -q '^second-held$' "$TEST_LOCK_LOG"; then
+  echo "second lifecycle holder entered before first released the lock" >&2
+  exit 1
+fi
+
+: >"$TEST_RELEASE_FIRST"
+wait "$first_pid"
+wait "$second_pid"
+
+grep -q '^first-released$' "$TEST_LOCK_LOG" || {
+  echo "first lifecycle holder did not release the lock" >&2
+  exit 1
+}
+grep -q '^second-held$' "$TEST_LOCK_LOG" || {
+  echo "second lifecycle holder did not acquire the lock after release" >&2
+  exit 1
+}
+
+echo "openclash_lifecycle_lock_test.sh: PASS"

--- a/tests/openclash_start_generation_test.sh
+++ b/tests/openclash_start_generation_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INIT_SCRIPT="$REPO_ROOT/luci-app-openclash/root/etc/init.d/openclash"
+
+if ! grep -F 'START_ID_FILE="/tmp/openclash_start_id"' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "init script does not define a start generation file" >&2
+  exit 1
+fi
+
+if ! grep -F 'OPENCLASH_START_ID="$$-$(date +%s)"' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "start_service does not create a per-start generation id" >&2
+  exit 1
+fi
+
+if ! PATTERN='if ! echo "\$OPENCLASH_START_ID" > "\$START_ID_FILE"; then.*?del_lifecycle_lock.*?exit 1' perl -0ne 'exit(/$ENV{PATTERN}/s ? 0 : 1)' "$INIT_SCRIPT"; then
+  echo "start_service does not fail closed when the start generation id cannot be written" >&2
+  exit 1
+fi
+
+if ! grep -F 'check_core_status "start" "$OPENCLASH_START_ID"' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "background core status check does not receive the start generation id" >&2
+  exit 1
+fi
+
+if ! grep -F 'Skip Stale Core Status Failure' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "start_fail does not skip stale background status checks" >&2
+  exit 1
+fi
+
+if ! grep -F 'rm -f "$START_ID_FILE"' "$INIT_SCRIPT" >/dev/null 2>&1; then
+  echo "stop_service does not clear the start generation id" >&2
+  exit 1
+fi
+
+if ! awk '
+  /^stop_service\(\)/ { in_stop = 1; next }
+  in_stop && /rm -f "\$START_ID_FILE"/ { saw_clear = 1 }
+  in_stop && /get_config/ { exit(saw_clear ? 0 : 1) }
+  in_stop && /^}/ { exit 1 }
+' "$INIT_SCRIPT"; then
+  echo "stop_service should clear the start generation id before any stop work can race with stale checks" >&2
+  exit 1
+fi
+
+echo "openclash_start_generation_test.sh: PASS"


### PR DESCRIPTION
## 变更

合并三个原本拆开的 OpenClash 启停生命周期竞态修复：

- 取代 #5220：区分 core procd instance 和 watchdog instance，避免把 watchdog 存活误判成 core 已运行。
- 取代 #5221：为每次 start 写入 generation id，旧后台启动检查不能反向影响新一轮 start/stop。
- 取代 #5225：用稳定 lifecycle lock 串行化 start/stop 以及共享 `/tmp/yaml_*` 临时状态。

这三个拆分 PR 都围绕 `luci-app-openclash/root/etc/init.d/openclash`，组合审核时会出现真实冲突和顺序依赖；合并成一个 PR 后，生命周期语义可以一次性审查。

## 关键处理

- `start_service` 先持有 lifecycle lock，再检查 `procd_running "openclash" "openclash"`。
- `START_ID_FILE` 写入失败会 fail closed 并释放 lifecycle lock。
- 后台 `check_core_status` 子进程先关闭继承的 lifecycle lock fd，避免子进程释放父进程持有的锁。
- `stop_service` 在持锁后、任何 stop 主体工作前清理 start generation，避免旧后台检查在 stop/restart 窗口里误判当前启动失败。

## 验证

- `bash tests/openclash_core_instance_state_test.sh`
- `bash tests/openclash_start_generation_test.sh`
- `bash tests/openclash_lifecycle_lock_test.sh`
- `sh -n luci-app-openclash/root/etc/init.d/openclash`
- `bash -n luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh`
- `git diff --check origin/dev...HEAD`
- `rg '^(<<<<<<<|=======|>>>>>>>)' luci-app-openclash tests`
- 多轮对抗式复核，最终无修改点
