### PR TITLE
fix: 合并更新锁和版本状态健壮性修复

### DIFF
--- a/luci-app-openclash/luasrc/controller/openclash.lua
+++ b/luci-app-openclash/luasrc/controller/openclash.lua
@@ -190,9 +190,9 @@ local function coremodel()
 		return opkg.info("libc")["libc"]["Architecture"]
 	else
 		if fs.pkg_type() == "opkg" then
-			return luci.sys.exec("rm -f /var/lock/opkg.lock && opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' 2>/dev/null")
+			return luci.sys.exec("opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' 2>/dev/null")
 		else
-			return luci.sys.exec("rm -f /lib/apk/db/lock && apk list libc 2>/dev/null |awk '{print $2}'")
+			return luci.sys.exec("apk list libc 2>/dev/null |awk '{print $2}'")
 		end
 	end
 end
@@ -246,9 +246,9 @@ local function opcv()
 		v = info["luci-app-openclash"]["Version"]
 	else
 		if fs.pkg_type() == "opkg" then
-			v = luci.sys.exec("rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' |tr -d '\n'")
+			v = luci.sys.exec("opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' |tr -d '\n'")
 		else
-			v = luci.sys.exec("rm -f /lib/apk/db/lock && apk list luci-app-openclash 2>/dev/null|grep 'installed' | grep -oE '[0-9]+(\\.[0-9]+)*' | head -1 |tr -d '\n'")
+			v = luci.sys.exec("apk list luci-app-openclash 2>/dev/null|grep 'installed' | grep -oE '[0-9]+(\\.[0-9]+)*' | head -1 |tr -d '\n'")
 		end
 	end
 	if v and v ~= "" then

--- a/luci-app-openclash/luasrc/openclash.lua
+++ b/luci-app-openclash/luasrc/openclash.lua
@@ -606,9 +606,9 @@ end
 function oc_version()
 	local v
 	if pkg_type() == "opkg" then
-		v = SYS.exec("rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep '^Version:' |awk '{print $2}' |tr -d '\n'")
+		v = SYS.exec("opkg status luci-app-openclash 2>/dev/null |grep '^Version:' |awk '{print $2}' |tr -d '\n'")
 	else
-		v = SYS.exec("rm -f /lib/apk/db/lock && apk info luci-app-openclash 2>/dev/null |grep '^luci-app-openclash-[0-9]' |sed 's/luci-app-openclash-//' |tr -d '\n'")
+		v = SYS.exec("apk info luci-app-openclash 2>/dev/null |grep '^luci-app-openclash-[0-9]' |sed 's/luci-app-openclash-//' |tr -d '\n'")
 	end
 	if v == "" then
 		v = "0"

--- a/luci-app-openclash/root/usr/share/openclash/clash_version.sh
+++ b/luci-app-openclash/root/usr/share/openclash/clash_version.sh
@@ -9,7 +9,6 @@ set_lock() {
 
 del_lock() {
    flock -u 884 2>/dev/null
-   rm -rf "/tmp/lock/openclash_clash_version.lock" 2>/dev/null
 }
 
 set_lock
@@ -44,4 +43,13 @@ else
 fi
 
 DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "$DOWNLOAD_FILE" "$DOWNLOAD_FILE"
+DOWNLOAD_RESULT=$?
+
+if [ "$DOWNLOAD_RESULT" -ne 0 ] && { [ "$DOWNLOAD_RESULT" -ne 2 ] || [ ! -f "$DOWNLOAD_FILE" ]; }; then
+   rm -f "$DOWNLOAD_FILE" >/dev/null 2>&1
+   del_lock
+   exit 1
+fi
+
 del_lock
+exit 0

--- a/luci-app-openclash/root/usr/share/openclash/openclash.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash.sh
@@ -14,7 +14,6 @@ set_lock() {
 
 del_lock() {
    flock -u 889 2>/dev/null
-   rm -rf "/tmp/lock/openclash_subs.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_chnroute.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_chnroute.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 879 2>/dev/null
-   rm -rf "/tmp/lock/openclash_chn.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_core.sh
@@ -12,7 +12,6 @@ set_lock() {
 
 del_lock() {
    flock -u 872 2>/dev/null
-   rm -rf "/tmp/lock/openclash_core.lock" 2>/dev/null
 }
 
 set_lock
@@ -45,12 +44,15 @@ RELEASE_BRANCH=$(uci_get_config "release_branch" || echo "master")
 
 if [ "$github_address_mod" != "0" ]; then
    /usr/share/openclash/clash_version.sh "$github_address_mod" 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 else
    /usr/share/openclash/clash_version.sh 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 fi
-if [ ! -f "/tmp/clash_last_version" ]; then
+if [ "$VERSION_CHECK_RESULT" -ne 0 ] || [ ! -f "/tmp/clash_last_version" ]; then
    LOG_ERROR "【"$CORE_TYPE"】Core Version Check Error, Please Try Again Later..."
    SLOG_CLEAN
+   dec_job_counter_and_restart "0"
    del_lock
    exit 0
 fi

--- a/luci-app-openclash/root/usr/share/openclash/openclash_custom_domain_dns.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_custom_domain_dns.sh
@@ -9,7 +9,6 @@ set_lock() {
 
 del_lock() {
    flock -u 883 2>/dev/null
-   rm -rf "/tmp/lock/openclash_cus_domian.lock"
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_debug.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_debug.sh
@@ -10,15 +10,14 @@ set_lock() {
 
 del_lock() {
    flock -u 885 2>/dev/null
-   rm -rf "/tmp/lock/openclash_debug.lock" 2>/dev/null
 }
 
 ipk_v()
 {
    if [ -x "/bin/opkg" ]; then
-      echo $(rm -f /var/lock/opkg.lock && opkg status "$1" 2>/dev/null |grep 'Version' |awk -F ': ' '{print $2}' 2>/dev/null)
+      echo $(opkg status "$1" 2>/dev/null |grep 'Version' |awk -F ': ' '{print $2}' 2>/dev/null)
    elif [ -x "/usr/bin/apk" ]; then
-      echo $(rm -f /lib/apk/db/lock && apk list "$1" 2>/dev/null |grep 'installed' | grep -oE '\d+(\.\d+)*' | head -1)
+      echo $(apk list "$1" 2>/dev/null |grep 'installed' | grep -oE '\d+(\.\d+)*' | head -1)
    fi
 }
 
@@ -42,9 +41,9 @@ RAW_CONFIG_FILE=$(uci_get_config "config_path")
 CONFIG_FILE="/etc/openclash/$(uci_get_config "config_path" |awk -F '/' '{print $5}' 2>/dev/null)"
 core_model=$(uci_get_config "core_version")
 if [ -x "/bin/opkg" ]; then
-   cpu_model=$(rm -f /var/lock/opkg.lock && opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' 2>/dev/null)
+   cpu_model=$(opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' 2>/dev/null)
 elif [ -x "/usr/bin/apk" ]; then
-   cpu_model=$(rm -f /lib/apk/db/lock && apk list libc 2>/dev/null|awk '{print $2}')
+   cpu_model=$(apk list libc 2>/dev/null|awk '{print $2}')
 fi
 core_meta_version=$(/etc/openclash/core/clash_meta -v 2>/dev/null |awk -F ' ' '{print $3}' |head -1 2>/dev/null)
 op_version=$(ipk_v "luci-app-openclash")

--- a/luci-app-openclash/root/usr/share/openclash/openclash_download_dashboard.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_download_dashboard.sh
@@ -11,7 +11,6 @@
 
    del_lock() {
       flock -u 871 2>/dev/null
-      rm -rf "/tmp/lock/openclash_dashboard.lock" 2>/dev/null
    }
 
    validate_dashboard_dir() {

--- a/luci-app-openclash/root/usr/share/openclash/openclash_geo.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_geo.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 888 2>/dev/null
-   rm -rf "/tmp/lock/openclash_update_databases.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_history_get.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_history_get.sh
@@ -10,7 +10,6 @@ set_lock() {
 
 del_lock() {
    flock -u 881 2>/dev/null
-   rm -rf "/tmp/lock/openclash_history_get.lock" 2>/dev/null
 }
 
 close_all_conection() {
@@ -50,7 +49,7 @@ if [ -z "$CONFIG_FILE" ] || [ ! -f "$CONFIG_FILE" ]; then
 fi
 
 if [ -n "$(pidof clash)" ] && [ -f "$CONFIG_FILE" ]; then
-   if [ "$small_flash_memory" == "1" ] || [ -n "$(echo $core_version |grep mips)" ] || [ -n "$(echo $DISTRIB_ARCH |grep mips)" ] || [ -n "$(rm -f /var/lock/opkg.lock && opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' |grep mips)" ] || [ -n "$(rm -f /lib/apk/db/lock && apk list libc 2>/dev/null |grep mips)" ]; then
+   if [ "$small_flash_memory" == "1" ] || [ -n "$(echo $core_version |grep mips)" ] || [ -n "$(echo $DISTRIB_ARCH |grep mips)" ] || [ -n "$(opkg status libc 2>/dev/null |grep 'Architecture' |awk -F ': ' '{print $2}' |grep mips)" ] || [ -n "$(apk list libc 2>/dev/null |grep mips)" ]; then
       CACHE_PATH="/tmp/etc/openclash/cache.db"
       if [ -f "$CACHE_PATH" ]; then
          cmp -s "$CACHE_PATH" "$HISTORY_PATH"

--- a/luci-app-openclash/root/usr/share/openclash/openclash_lgbm.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_lgbm.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 868 2>/dev/null
-   rm -rf "/tmp/lock/openclash_lgbm.lock" 2>/dev/null
 }
 
 set_lock

--- a/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_update.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 878 2>/dev/null
-   rm -rf "/tmp/lock/openclash_update.lock" 2>/dev/null
 }
 
 set_lock
@@ -19,13 +18,16 @@ inc_job_counter
 
 if [ -n "$1" ] && [ "$1" != "one_key_update" ]; then
    /usr/share/openclash/openclash_version.sh "$1" 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 elif [ -n "$2" ]; then
    /usr/share/openclash/openclash_version.sh "$2" 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 else
    /usr/share/openclash/openclash_version.sh 2>/dev/null
+   VERSION_CHECK_RESULT=$?
 fi
 
-if [ ! -f "/tmp/openclash_last_version" ]; then
+if [ "$VERSION_CHECK_RESULT" -ne 0 ] || [ ! -f "/tmp/openclash_last_version" ]; then
    LOG_ERROR "Failed to get version information, please try again later..."
    SLOG_CLEAN
    dec_job_counter_and_restart "0"
@@ -73,9 +75,9 @@ run_with_timeout() {
 LAST_OPVER="/tmp/openclash_last_version"
 LAST_VER=$(sed -n 1p "$LAST_OPVER" 2>/dev/null |sed "s/^v//g" |tr -d "\n")
 if [ -x "/bin/opkg" ]; then
-   OP_CV=$(rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
+   OP_CV=$(opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
 elif [ -x "/usr/bin/apk" ]; then
-   OP_CV=$(rm -f /lib/apk/db/lock && apk list luci-app-openclash 2>/dev/null|grep "installed" | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
+   OP_CV=$(apk list luci-app-openclash 2>/dev/null|grep "installed" | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
 fi
 OP_LV=$(sed -n 1p "$LAST_OPVER" 2>/dev/null |sed "s/^v//g" |tr -d "\n")
 RELEASE_BRANCH=$(uci_get_config "release_branch" || echo "master")
@@ -156,7 +158,6 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
                update_retry=$((update_retry + 1))
                run_with_timeout 30 opkg update >/dev/null 2>&1
                opkg_ret=$?
-               rm -f /var/lock/opkg.lock
                if [ $opkg_ret -eq 0 ]; then
                   break
                fi
@@ -179,7 +180,6 @@ if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ 
                update_retry=$((update_retry + 1))
                run_with_timeout 30 apk update >/dev/null 2>&1
                apk_ret=$?
-               rm -f /lib/apk/db/lock
                if [ $apk_ret -eq 0 ]; then
                   break
                fi
@@ -249,7 +249,6 @@ set_update_lock() {
 
 del_update_lock() {
    flock -u 879 2>/dev/null
-   rm -rf "$UPDATE_LOCK" 2>/dev/null
 }
 
 if ! set_update_lock; then
@@ -265,7 +264,7 @@ check_install_success()
    local current_version=""
 
    if [ -x "/bin/opkg" ]; then
-      current_version=$(rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
+      current_version=$(opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
    elif [ -x "/usr/bin/apk" ]; then
       current_version=$(apk list luci-app-openclash 2>/dev/null |grep "installed" | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
    fi

--- a/luci-app-openclash/root/usr/share/openclash/openclash_version.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_version.sh
@@ -9,7 +9,6 @@ set_lock() {
 
 del_lock() {
    flock -u 869 2>/dev/null
-   rm -rf "/tmp/lock/openclash_version.lock" 2>/dev/null
 }
 
 set_lock
@@ -35,9 +34,9 @@ version_compare() {
 DOWNLOAD_FILE="/tmp/openclash_last_version"
 RELEASE_BRANCH=$(uci_get_config "release_branch" || echo "master")
 if [ -x "/bin/opkg" ]; then
-   OP_CV=$(rm -f /var/lock/opkg.lock && opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
+   OP_CV=$(opkg status luci-app-openclash 2>/dev/null |grep 'Version' |awk -F 'Version: ' '{print $2}' 2>/dev/null)
 elif [ -x "/usr/bin/apk" ]; then
-   OP_CV=$(rm -f /lib/apk/db/lock && apk list luci-app-openclash 2>/dev/null|grep 'installed' | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
+   OP_CV=$(apk list luci-app-openclash 2>/dev/null|grep 'installed' | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 2>/dev/null)
 fi
 OP_LV=$(sed -n 1p "$DOWNLOAD_FILE" 2>/dev/null |sed "s/^v//g" |tr -d "\n")
 github_address_mod=$(uci_get_config "github_address_mod" || echo 0)
@@ -56,12 +55,18 @@ else
 fi
 
 DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "$DOWNLOAD_FILE" "$DOWNLOAD_FILE"
+DOWNLOAD_RESULT=$?
 
-if [ "$?" -eq 0 ]; then
-   OP_LV=$(sed -n 1p $DOWNLOAD_FILE 2>/dev/null |awk -F 'v' '{print $2}' |awk -F '.' '{print $2$3}' 2>/dev/null)
-   if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ -f "$DOWNLOAD_FILE" ]; then
-      sed -i '/^https:/,$d' $DOWNLOAD_FILE
-   fi
+if [ "$DOWNLOAD_RESULT" -ne 0 ] && { [ "$DOWNLOAD_RESULT" -ne 2 ] || [ ! -f "$DOWNLOAD_FILE" ]; }; then
+   rm -f "$DOWNLOAD_FILE" >/dev/null 2>&1
+   del_lock
+   exit 1
+fi
+
+OP_LV=$(sed -n 1p "$DOWNLOAD_FILE" 2>/dev/null |awk -F 'v' '{print $2}' |awk -F '.' '{print $2$3}' 2>/dev/null)
+if [ -n "$OP_CV" ] && [ -n "$OP_LV" ] && version_compare "$OP_CV" "$OP_LV" && [ -f "$DOWNLOAD_FILE" ]; then
+   sed -i '/^https:/,$d' "$DOWNLOAD_FILE"
 fi
 
 del_lock
+exit 0

--- a/luci-app-openclash/root/usr/share/openclash/yml_groups_get.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_groups_get.sh
@@ -10,7 +10,6 @@ set_lock() {
 
 del_lock() {
    flock -u 876 2>/dev/null
-   rm -rf "/tmp/lock/openclash_groups_get.lock"
 }
 
 CONFIG_FILE=$(uci_get_config "config_path")

--- a/luci-app-openclash/root/usr/share/openclash/yml_groups_set.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_groups_set.sh
@@ -10,7 +10,6 @@ set_lock() {
 
 del_lock() {
    flock -u 887 2>/dev/null
-   rm -rf "/tmp/lock/openclash_groups_set.lock"
 }
 
 set_lock
@@ -329,4 +328,3 @@ sed -i "s/#delete_//g" "$CONFIG_FILE" 2>/dev/null
 
 /usr/share/openclash/yml_proxys_set.sh "$CONFIG_FILE" >/dev/null 2>&1
 del_lock
-

--- a/luci-app-openclash/root/usr/share/openclash/yml_proxys_get.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_proxys_get.sh
@@ -10,7 +10,6 @@ set_lock() {
 
 del_lock() {
    flock -u 875 2>/dev/null
-   rm -rf "/tmp/lock/openclash_proxies_get.lock"
 }
 
 CONFIG_FILE=$(uci_get_config "config_path")

--- a/luci-app-openclash/root/usr/share/openclash/yml_proxys_set.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_proxys_set.sh
@@ -11,7 +11,6 @@ set_lock() {
 
 del_lock() {
    flock -u 886 2>/dev/null
-   rm -rf "/tmp/lock/openclash_proxies_set.lock"
 }
 
 SERVER_FILE="/tmp/yaml_servers.yaml"

--- a/tests/openclash_flock_lockfile_test.sh
+++ b/tests/openclash_flock_lockfile_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MATCH_FILE="${TMPDIR:-/tmp}/openclash-flock-lock-rm.$$"
+trap 'rm -f "$MATCH_FILE"' EXIT
+
+if grep -RInE 'rm -.*(/tmp/lock/openclash|[$]UPDATE_LOCK)' \
+  "$REPO_ROOT/luci-app-openclash/root/usr/share/openclash" \
+  "$REPO_ROOT/luci-app-openclash/root/etc/init.d/openclash" >"$MATCH_FILE"; then
+  echo "OpenClash flock lock files must not be removed after unlock:" >&2
+  cat "$MATCH_FILE" >&2
+  exit 1
+fi
+
+echo "openclash_flock_lockfile_test.sh: PASS"

--- a/tests/openclash_package_lock_test.sh
+++ b/tests/openclash_package_lock_test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MATCH_FILE="${TMPDIR:-/tmp}/openclash-package-lock-rm.$$"
+trap 'rm -f "$MATCH_FILE"' EXIT
+
+if grep -RInE 'rm -.*(/var/lock/opkg\.lock|/lib/apk/db/lock)' \
+  "$REPO_ROOT/luci-app-openclash" >"$MATCH_FILE"; then
+  echo "OpenClash scripts must not remove system package manager locks:" >&2
+  cat "$MATCH_FILE" >&2
+  exit 1
+fi
+
+echo "openclash_package_lock_test.sh: PASS"

--- a/tests/openclash_version_state_test.sh
+++ b/tests/openclash_version_state_test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/openclash-version-state-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/usr/share/openclash" "$WORKDIR/tmp/lock" "$WORKDIR/lib"
+
+cat >"$WORKDIR/usr/share/openclash/openclash_curl.sh" <<'STUB'
+DOWNLOAD_FILE_CURL() {
+   if [ -n "${OPENCLASH_TEST_CURL_COUNT_FILE:-}" ]; then
+      count="$(cat "$OPENCLASH_TEST_CURL_COUNT_FILE" 2>/dev/null || echo 0)"
+      echo $((count + 1)) >"$OPENCLASH_TEST_CURL_COUNT_FILE"
+   fi
+
+   case "${OPENCLASH_TEST_DOWNLOAD_RESULT:-0}" in
+      0)
+         if [ "${OPENCLASH_TEST_VERSION_KIND:-core}" = "package" ]; then
+            printf 'v9.99.9\nhttps://example.invalid/pkg\n' >"$2"
+         else
+            printf 'new-core\nnew-smart\n' >"$2"
+         fi
+         return 0
+      ;;
+      2)
+         return 2
+      ;;
+      *)
+         return 1
+      ;;
+   esac
+}
+STUB
+
+cat >"$WORKDIR/usr/share/openclash/uci.sh" <<'STUB'
+uci_get_config() {
+   return 1
+}
+STUB
+
+cat >"$WORKDIR/usr/share/openclash/log.sh" <<'STUB'
+LOG_ERROR() {
+   printf '%s\n' "$*" >>"${OPENCLASH_TEST_LOG:-/dev/null}"
+}
+LOG_TIP() {
+   printf '%s\n' "$*" >>"${OPENCLASH_TEST_LOG:-/dev/null}"
+}
+SLOG_CLEAN() {
+   :
+}
+STUB
+
+cat >"$WORKDIR/usr/share/openclash/openclash_ps.sh" <<'STUB'
+inc_job_counter() {
+   printf 'inc\n' >>"${OPENCLASH_TEST_JOBS:-/dev/null}"
+}
+dec_job_counter_and_restart() {
+   printf 'dec:%s\n' "$1" >>"${OPENCLASH_TEST_JOBS:-/dev/null}"
+}
+STUB
+
+touch "$WORKDIR/lib/functions.sh"
+
+copy_script() {
+   local src="$1"
+   local dst="$2"
+
+   cp "$REPO_ROOT/$src" "$dst"
+   perl -0pi -e "s#/usr/share/openclash/#$WORKDIR/usr/share/openclash/#g; s#/lib/functions\\.sh#$WORKDIR/lib/functions.sh#g; s#/tmp/lock/#$WORKDIR/tmp/lock/#g; s#/tmp/clash_last_version#$WORKDIR/tmp/clash_last_version#g; s#/tmp/openclash_last_version#$WORKDIR/tmp/openclash_last_version#g" "$dst"
+   chmod +x "$dst"
+}
+
+copy_script "luci-app-openclash/root/usr/share/openclash/clash_version.sh" "$WORKDIR/clash_version.sh"
+copy_script "luci-app-openclash/root/usr/share/openclash/openclash_version.sh" "$WORKDIR/openclash_version.sh"
+cp "$WORKDIR/clash_version.sh" "$WORKDIR/usr/share/openclash/clash_version.sh"
+cp "$WORKDIR/openclash_version.sh" "$WORKDIR/usr/share/openclash/openclash_version.sh"
+copy_script "luci-app-openclash/root/usr/share/openclash/openclash_core.sh" "$WORKDIR/openclash_core.sh"
+copy_script "luci-app-openclash/root/usr/share/openclash/openclash_update.sh" "$WORKDIR/openclash_update.sh"
+
+printf 'stale-core\n' >"$WORKDIR/tmp/clash_last_version"
+if OPENCLASH_TEST_DOWNLOAD_RESULT=1 "$WORKDIR/clash_version.sh"; then
+   echo "expected failed core version check to return non-zero" >&2
+   exit 1
+fi
+[ ! -e "$WORKDIR/tmp/clash_last_version" ] || {
+   echo "failed core version check should not leave stale version state" >&2
+   exit 1
+}
+
+OPENCLASH_TEST_DOWNLOAD_RESULT=0 "$WORKDIR/clash_version.sh"
+[ "$(sed -n 1p "$WORKDIR/tmp/clash_last_version")" = "new-core" ] || {
+   echo "successful core version check did not publish new state" >&2
+   exit 1
+}
+
+printf 'cached-core\n' >"$WORKDIR/tmp/clash_last_version"
+OPENCLASH_TEST_DOWNLOAD_RESULT=2 "$WORKDIR/clash_version.sh"
+[ "$(sed -n 1p "$WORKDIR/tmp/clash_last_version")" = "cached-core" ] || {
+   echo "304 core version check should keep cached state" >&2
+   exit 1
+}
+rm -f "$WORKDIR/tmp/clash_last_version"
+if OPENCLASH_TEST_DOWNLOAD_RESULT=2 "$WORKDIR/clash_version.sh"; then
+   echo "304 core version check without cached state should fail closed" >&2
+   exit 1
+fi
+
+printf 'v1.2.3\nhttps://stale.invalid/pkg\n' >"$WORKDIR/tmp/openclash_last_version"
+if OPENCLASH_TEST_VERSION_KIND=package OPENCLASH_TEST_DOWNLOAD_RESULT=1 "$WORKDIR/openclash_version.sh"; then
+   echo "expected failed package version check to return non-zero" >&2
+   exit 1
+fi
+[ ! -e "$WORKDIR/tmp/openclash_last_version" ] || {
+   echo "failed package version check should not leave stale version state" >&2
+   exit 1
+}
+
+OPENCLASH_TEST_VERSION_KIND=package OPENCLASH_TEST_DOWNLOAD_RESULT=0 "$WORKDIR/openclash_version.sh"
+[ "$(sed -n 1p "$WORKDIR/tmp/openclash_last_version")" = "v9.99.9" ] || {
+   echo "successful package version check did not publish new state" >&2
+   exit 1
+}
+
+printf 'v7.7.7\nhttps://cached.invalid/pkg\n' >"$WORKDIR/tmp/openclash_last_version"
+OPENCLASH_TEST_VERSION_KIND=package OPENCLASH_TEST_DOWNLOAD_RESULT=2 "$WORKDIR/openclash_version.sh"
+[ "$(sed -n 1p "$WORKDIR/tmp/openclash_last_version")" = "v7.7.7" ] || {
+   echo "304 package version check should keep cached state" >&2
+   exit 1
+}
+rm -f "$WORKDIR/tmp/openclash_last_version"
+if OPENCLASH_TEST_VERSION_KIND=package OPENCLASH_TEST_DOWNLOAD_RESULT=2 "$WORKDIR/openclash_version.sh"; then
+   echo "304 package version check without cached state should fail closed" >&2
+   exit 1
+fi
+
+rg -Fq 'VERSION_CHECK_RESULT=$?' "$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_core.sh"
+rg -Fq 'VERSION_CHECK_RESULT=$?' "$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_update.sh"
+
+printf 'v1.2.3\nhttps://stale.invalid/pkg\n' >"$WORKDIR/tmp/openclash_last_version"
+echo 0 >"$WORKDIR/update-count"
+OPENCLASH_TEST_VERSION_KIND=package \
+OPENCLASH_TEST_DOWNLOAD_RESULT=1 \
+OPENCLASH_TEST_CURL_COUNT_FILE="$WORKDIR/update-count" \
+OPENCLASH_TEST_LOG="$WORKDIR/update.log" \
+   "$WORKDIR/openclash_update.sh"
+[ "$(cat "$WORKDIR/update-count")" = "1" ] || {
+   echo "package update caller should stop after failed version refresh" >&2
+   exit 1
+}
+grep -q "Failed to get version information" "$WORKDIR/update.log" || {
+   echo "package update caller did not report failed version refresh" >&2
+   exit 1
+}
+
+printf 'stale-core\n' >"$WORKDIR/tmp/clash_last_version"
+echo 0 >"$WORKDIR/core-count"
+OPENCLASH_TEST_DOWNLOAD_RESULT=1 \
+OPENCLASH_TEST_CURL_COUNT_FILE="$WORKDIR/core-count" \
+OPENCLASH_TEST_LOG="$WORKDIR/core.log" \
+OPENCLASH_TEST_JOBS="$WORKDIR/core-jobs.log" \
+   "$WORKDIR/openclash_core.sh" Meta
+[ "$(cat "$WORKDIR/core-count")" = "1" ] || {
+   echo "core update caller should stop after failed version refresh" >&2
+   exit 1
+}
+grep -q '^dec:0$' "$WORKDIR/core-jobs.log" || {
+   echo "core update caller did not decrement job counter after failed version refresh" >&2
+   exit 1
+}
+grep -q "Core Version Check Error" "$WORKDIR/core.log" || {
+   echo "core update caller did not report failed version refresh" >&2
+   exit 1
+}
+
+echo "openclash_version_state tests passed"


### PR DESCRIPTION
## 变更

合并三个原本拆开的更新/版本状态健壮性修复：

- 取代 #5217：OpenClash 不再无条件删除 opkg/apk 系统包管理器锁。
- 取代 #5218：OpenClash 自有 `flock` 锁文件保持稳定，不再解锁后删除 lock 文件。
- 取代 #5222：版本刷新失败时删除 stale version state 并返回失败，调用方不能复用旧 `/tmp/*_last_version`。

这三个拆分 PR 都位于更新/版本状态路径，并且组合时会在 `openclash_version.sh` 产生真实冲突；合并后，审核者可以一次性确认完整的更新健壮性语义。

## 关键处理

- `clash_version.sh` / `openclash_version.sh` 捕获 `DOWNLOAD_FILE_CURL` 返回值。
- 下载失败删除 stale version state 并返回非零。
- 304 只有在目标状态文件仍存在时才视为有效，否则 fail closed。
- `openclash_core.sh` / `openclash_update.sh` 在使用 version state 前检查刷新结果。
- `openclash_core.sh` 在版本刷新失败早退前会调用 `dec_job_counter_and_restart "0"`，避免泄漏 OpenClash job counter。

## 验证

- `bash tests/openclash_package_lock_test.sh`
- `bash tests/openclash_flock_lockfile_test.sh`
- `bash tests/openclash_version_state_test.sh`
- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`
- `git diff --check origin/dev...HEAD`
- `rg '^(<<<<<<<|=======|>>>>>>>)' luci-app-openclash tests`
- 多轮对抗式复核，最终无修改点
