### PR TITLE
fix LightGBM model download fallback

### DIFF
--- a/luci-app-openclash/po/es/openclash.es.po
+++ b/luci-app-openclash/po/es/openclash.es.po
@@ -3624,6 +3624,9 @@ msgstr "Configuración en ejecución (solo lectura)"
 msgid "Start Downloading LightGBM Model..."
 msgstr "Comenzando descarga del modelo LightGBM..."
 
+msgid "Direct LightGBM Model Download Failed, Retrying Through OpenClash Proxy..."
+msgstr "La descarga directa del modelo LightGBM falló; reintentando mediante el proxy de OpenClash..."
+
 msgid "LightGBM Model Download Success, Check Updated..."
 msgstr "Modelo LightGBM descargado correctamente, comprobando actualizaciones..."
 

--- a/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
+++ b/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
@@ -3639,6 +3639,9 @@ msgstr "运行配置（只读）"
 msgid "Start Downloading LightGBM Model..."
 msgstr "开始下载 LightGBM 模型..."
 
+msgid "Direct LightGBM Model Download Failed, Retrying Through OpenClash Proxy..."
+msgstr "LightGBM 模型直连下载失败，正在通过 OpenClash 代理重试..."
+
 msgid "LightGBM Model Download Success, Check Updated..."
 msgstr "LightGBM 模型下载成功，检查是否有更新..."
 

--- a/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh
@@ -2,6 +2,27 @@
 . /usr/share/openclash/log.sh
 . /usr/share/openclash/openclash_etag.sh
 
+DOWNLOAD_CURL_CONFIG_ESCAPE() {
+    sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+DOWNLOAD_CURL_CONFIG_VALUE_SAFE() {
+    [ "$(printf '%s' "$1" | tr -d '\r\n')" = "$1" ]
+}
+
+DOWNLOAD_CURL() {
+    local proxy_auth
+
+    if [ -n "$DOWNLOAD_PROXY" ] && [ -n "$DOWNLOAD_PROXY_USER" ] && [ -n "$DOWNLOAD_PROXY_PASSWORD" ]; then
+        DOWNLOAD_CURL_CONFIG_VALUE_SAFE "$DOWNLOAD_PROXY_USER" || return 1
+        DOWNLOAD_CURL_CONFIG_VALUE_SAFE "$DOWNLOAD_PROXY_PASSWORD" || return 1
+        proxy_auth=$(printf '%s:%s' "$DOWNLOAD_PROXY_USER" "$DOWNLOAD_PROXY_PASSWORD" | DOWNLOAD_CURL_CONFIG_ESCAPE)
+        printf 'proxy-user = "%s"\n' "$proxy_auth" | curl --config - "$@"
+    else
+        curl "$@"
+    fi
+}
+
 DOWNLOAD_FAILURE_OUTPUT() {
     failure_exit_code="$1"
     failure_http_code="$2"
@@ -19,6 +40,10 @@ DOWNLOAD_FAILURE_OUTPUT() {
 }
 
 DOWNLOAD_FILE_CURL() {
+    local DOWNLOAD_PROXY="${7:-}"
+    local DOWNLOAD_PROXY_USER="${8:-}"
+    local DOWNLOAD_PROXY_PASSWORD="${9:-}"
+
     [ -z "$1" ] || [ -z "$2" ] && return 1
     DOWNLOAD_URL=$1
     DOWNLOAD_PATH=$2
@@ -50,6 +75,7 @@ DOWNLOAD_FILE_CURL() {
 $CUSTOM_HEADERS
 EOF
     fi
+    [ -n "$DOWNLOAD_PROXY" ] && set -- "$@" --proxy "$DOWNLOAD_PROXY"
 
     if [ "$SHOW_DOWNLOAD_PROGRESS" = "1" ] || [ "$SHOW_DOWNLOAD_PROGRESS" = "true" ]; then
         TEMP_LOG="/tmp/curl_log_$$"
@@ -58,7 +84,7 @@ EOF
 
         (
             if [ -n "$SECRET_KEY" ] && [ -n "$ETAG_HEADER" ]; then
-                curl -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                DOWNLOAD_CURL -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
                     -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
                     -H "X-Age-Public-Key: ${SECRET_KEY}" \
@@ -66,21 +92,21 @@ EOF
                     "$@" \
                     "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>"$TEMP_LOG"
             elif [ -n "$SECRET_KEY" ]; then
-                curl -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                DOWNLOAD_CURL -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
                     -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
                     -H "X-Age-Public-Key: ${SECRET_KEY}" \
                     "$@" \
                     "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>"$TEMP_LOG"
             elif [ -n "$ETAG_HEADER" ]; then
-                curl -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                DOWNLOAD_CURL -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
                     -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
                     -H "$ETAG_HEADER" \
                     "$@" \
                     "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>"$TEMP_LOG"
             else
-                curl -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                DOWNLOAD_CURL -# -L --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
                     -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
                     "$@" \
@@ -142,7 +168,7 @@ EOF
             DOWNLOAD_TRY=$((DOWNLOAD_TRY + 1))
             rm -f "$HEADER_TMP" "$DOWNLOAD_TMP"
             if [ -n "$SECRET_KEY" ] && [ -n "$ETAG_HEADER" ]; then
-                CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                CURL_OUTPUT=$(DOWNLOAD_CURL -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
                     -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
                     -H "X-Age-Public-Key: ${SECRET_KEY}" \
@@ -150,21 +176,21 @@ EOF
                     "$@" \
                     "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>&1)
             elif [ -n "$SECRET_KEY" ]; then
-                CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                CURL_OUTPUT=$(DOWNLOAD_CURL -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
                     -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
                     -H "X-Age-Public-Key: ${SECRET_KEY}" \
                     "$@" \
                     "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>&1)
             elif [ -n "$ETAG_HEADER" ]; then
-                CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                CURL_OUTPUT=$(DOWNLOAD_CURL -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
                     -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
                     -H "$ETAG_HEADER" \
                     "$@" \
                     "$DOWNLOAD_URL" -o "$DOWNLOAD_TMP" 2>&1)
             else
-                CURL_OUTPUT=$(curl -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
+                CURL_OUTPUT=$(DOWNLOAD_CURL -w "\n%{http_code}" -SsL --connect-timeout 30 -m 180 --speed-time 30 --speed-limit 1 --retry 2 \
                     -D "$HEADER_TMP" \
                     -H "User-Agent: ${DOWNLOAD_UA}" \
                     "$@" \

--- a/luci-app-openclash/root/usr/share/openclash/openclash_lgbm.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_lgbm.sh
@@ -1,4 +1,71 @@
 #!/bin/bash
+
+lgbm_valid_proxy_port() {
+   case "$1" in
+      ''|*[!0-9]*) return 1 ;;
+   esac
+   [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+}
+
+lgbm_auth_get() {
+   local section="$1"
+   local enabled username password
+
+   [ -z "$LGBM_PROXY_USERNAME" ] || return 0
+   config_get_bool enabled "$section" enabled 1
+   config_get username "$section" username ""
+   config_get password "$section" password ""
+   if [ "$enabled" != "0" ] && [ -n "$username" ] && [ -n "$password" ]; then
+      LGBM_PROXY_USERNAME="$username"
+      LGBM_PROXY_PASSWORD="$password"
+   fi
+}
+
+lgbm_load_proxy_auth() {
+   LGBM_PROXY_USERNAME=""
+   LGBM_PROXY_PASSWORD=""
+   config_load openclash >/dev/null 2>&1 || return 0
+   config_foreach lgbm_auth_get authentication
+}
+
+lgbm_proxy_url() {
+   local router_self_proxy mixed_port
+
+   router_self_proxy=$(uci_get_config "router_self_proxy" || echo 1)
+   [ "$router_self_proxy" = "1" ] || return 1
+   pidof clash >/dev/null 2>&1 || return 1
+
+   mixed_port=$(uci_get_config "mixed_port")
+   lgbm_valid_proxy_port "$mixed_port" || return 1
+   printf 'http://127.0.0.1:%s' "$mixed_port"
+}
+
+download_lgbm_model() {
+   local download_url="$1"
+   local download_path="$2"
+   local model_path="$3"
+   local download_result proxy_url
+
+   DOWNLOAD_FILE_CURL "$download_url" "$download_path" "$model_path"
+   download_result=$?
+   [ "$download_result" -eq 1 ] || return "$download_result"
+   case "$download_url" in
+      https://github.com/*) ;;
+      *) return "$download_result" ;;
+   esac
+
+   proxy_url=$(lgbm_proxy_url) || return "$download_result"
+   lgbm_load_proxy_auth
+   LOG_OUT "Direct LightGBM Model Download Failed, Retrying Through OpenClash Proxy..."
+   DOWNLOAD_FILE_CURL "$download_url" "$download_path" "$model_path" "" "" "" \
+      "$proxy_url" "$LGBM_PROXY_USERNAME" "$LGBM_PROXY_PASSWORD"
+}
+
+if [ "${OPENCLASH_TEST_ONLY:-0}" = "1" ]; then
+   return 0 2>/dev/null || exit 0
+fi
+
+. /lib/functions.sh
 . /usr/share/openclash/openclash_ps.sh
 . /usr/share/openclash/log.sh
 . /usr/share/openclash/openclash_curl.sh
@@ -34,7 +101,7 @@ if [ -z "$LGBM_CUSTOM_URL" ]; then
 else
    DOWNLOAD_URL=$LGBM_CUSTOM_URL
 fi
-DOWNLOAD_FILE_CURL "$DOWNLOAD_URL" "/tmp/Model.bin" "$lgbm_path"
+download_lgbm_model "$DOWNLOAD_URL" "/tmp/Model.bin" "$lgbm_path"
 DOWNLOAD_RESULT=$?
 if [ "$DOWNLOAD_RESULT" -eq 0 ] && [ -s "/tmp/Model.bin" ]; then
    LOG_OUT "LightGBM Model Download Success, Check Updated..."

--- a/tests/openclash_curl_proxy_test.sh
+++ b/tests/openclash_curl_proxy_test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CURL_SCRIPT="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_curl.sh"
+TEST_TMP="$(mktemp -d)"
+CURL_UNDER_TEST="$TEST_TMP/openclash_curl.sh"
+CURL_ARGS_FILE="$TEST_TMP/curl.args"
+CURL_CONFIG_FILE="$TEST_TMP/curl.config"
+CURL_ENV_FILE="$TEST_TMP/curl.env"
+CURL_CALLS_FILE="$TEST_TMP/curl.calls"
+LOG_FILE="$TEST_TMP/openclash.log"
+
+cleanup() {
+  rm -rf -- "$TEST_TMP"
+}
+trap cleanup EXIT
+
+sed \
+  -e '\|^\. /usr/share/openclash/log\.sh$|d' \
+  -e '\|^\. /usr/share/openclash/openclash_etag\.sh$|d' \
+  "$CURL_SCRIPT" > "$CURL_UNDER_TEST"
+
+GET_ETAG_BY_PATH() {
+  return 0
+}
+
+GET_ETAG_TIMESTAMP_BY_PATH() {
+  return 0
+}
+
+SAVE_ETAG_TO_CACHE() {
+  return 0
+}
+
+LOG_OUT() {
+  printf '%s\n' "$*" >> "$LOG_FILE"
+}
+
+SLOG_CLEAN() {
+  return 0
+}
+
+curl() {
+  local header_file=""
+  local output_file=""
+  local read_config=0
+  local argument
+
+  printf 'call\n' >> "$CURL_CALLS_FILE"
+  printf '%s\n' "$@" > "$CURL_ARGS_FILE"
+  env > "$CURL_ENV_FILE"
+  for argument in "$@"; do
+    if [[ "$argument" == "--config" ]]; then
+      read_config=1
+      break
+    fi
+  done
+  if [[ "$read_config" == "1" ]]; then
+    cat > "$CURL_CONFIG_FILE"
+  else
+    : > "$CURL_CONFIG_FILE"
+  fi
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -D)
+        header_file="$2"
+        shift 2
+        ;;
+      -o)
+        output_file="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  if [[ "${CURL_BEHAVIOR:-success}" == "failure" ]]; then
+    printf 'HTTP/1.1 502 Bad Gateway\r\n' > "$header_file"
+    printf 'partial-data' > "$output_file"
+    printf '\n502'
+  else
+    printf 'HTTP/1.1 200 OK\r\n' > "$header_file"
+    printf 'model-data' > "$output_file"
+    printf '\n200'
+  fi
+}
+
+source "$CURL_UNDER_TEST"
+SHOW_DOWNLOAD_PROGRESS=0
+CURL_BEHAVIOR=success
+
+DOWNLOAD_CURL_CONFIG_VALUE_SAFE "plain-value"
+if DOWNLOAD_CURL_CONFIG_VALUE_SAFE $'line\nbreak' ||
+   DOWNLOAD_CURL_CONFIG_VALUE_SAFE $'carriage\rreturn'; then
+  printf 'FAIL: curl config value accepted CR or LF\n' >&2
+  exit 1
+fi
+
+proxy_url="http://127.0.0.1:7893"
+proxy_user="Clash"
+proxy_password='p@ss:word\quote"'
+download_path="$TEST_TMP/Model.bin"
+model_path="$TEST_TMP/current.bin"
+
+set +e
+DOWNLOAD_FILE_CURL \
+  "https://github.com/vernesong/mihomo/releases/download/LightGBM-Model/Model.bin" \
+  "$download_path" "$model_path" "" "" "" \
+  "$proxy_url" "$proxy_user" "$proxy_password"
+download_status=$?
+set -e
+
+[[ "$download_status" == "0" ]]
+[[ "$(cat "$download_path")" == "model-data" ]]
+grep -Fx -- "--proxy" "$CURL_ARGS_FILE" >/dev/null
+grep -Fx -- "$proxy_url" "$CURL_ARGS_FILE" >/dev/null
+grep -Fx -- "--config" "$CURL_ARGS_FILE" >/dev/null
+if grep -F -- "$proxy_user" "$CURL_ARGS_FILE" >/dev/null ||
+   grep -F -- "$proxy_password" "$CURL_ARGS_FILE" >/dev/null; then
+  printf 'FAIL: proxy credentials leaked into curl argv\n' >&2
+  exit 1
+fi
+if grep -F -- "$proxy_password" "$CURL_ENV_FILE" >/dev/null; then
+  printf 'FAIL: proxy password leaked into curl environment\n' >&2
+  exit 1
+fi
+expected_config='proxy-user = "Clash:p@ss:word\\quote\""'
+grep -Fx -- "$expected_config" "$CURL_CONFIG_FILE" >/dev/null
+if grep -F -- "$proxy_password" "$LOG_FILE" >/dev/null 2>&1; then
+  printf 'FAIL: proxy password leaked into logs\n' >&2
+  exit 1
+fi
+
+SHOW_DOWNLOAD_PROGRESS=1
+: > "$CURL_CALLS_FILE"
+rm -f "$download_path"
+set +e
+DOWNLOAD_FILE_CURL \
+  "https://github.com/vernesong/mihomo/releases/download/LightGBM-Model/Model.bin" \
+  "$download_path" "$model_path" "" "" "" \
+  "$proxy_url" "$proxy_user" "$proxy_password" >/dev/null
+download_status=$?
+set -e
+
+[[ "$download_status" == "0" ]]
+[[ "$(cat "$download_path")" == "model-data" ]]
+[[ "$(wc -l < "$CURL_CALLS_FILE" | tr -d ' ')" == "1" ]]
+grep -Fx -- "--proxy" "$CURL_ARGS_FILE" >/dev/null
+grep -Fx -- "$proxy_url" "$CURL_ARGS_FILE" >/dev/null
+grep -Fx -- "--config" "$CURL_ARGS_FILE" >/dev/null
+if grep -F -- "$proxy_user" "$CURL_ARGS_FILE" >/dev/null ||
+   grep -F -- "$proxy_password" "$CURL_ARGS_FILE" >/dev/null ||
+   grep -F -- "$proxy_password" "$CURL_ENV_FILE" >/dev/null ||
+   grep -F -- "$proxy_password" "$LOG_FILE" >/dev/null 2>&1; then
+  printf 'FAIL: progress download leaked proxy credentials\n' >&2
+  exit 1
+fi
+
+SHOW_DOWNLOAD_PROGRESS=0
+set +e
+DOWNLOAD_FILE_CURL \
+  "https://github.com/vernesong/mihomo/releases/download/LightGBM-Model/Model.bin" \
+  "$download_path" "$model_path" "" "" "" "$proxy_url"
+download_status=$?
+set -e
+
+[[ "$download_status" == "0" ]]
+grep -Fx -- "--proxy" "$CURL_ARGS_FILE" >/dev/null
+if grep -Fx -- "--config" "$CURL_ARGS_FILE" >/dev/null; then
+  printf 'FAIL: unauthenticated proxy unexpectedly used a curl config\n' >&2
+  exit 1
+fi
+
+injected_marker="injected-review"
+injected_password=$'secret\nuser-agent = injected-review\n#'
+: > "$CURL_CALLS_FILE"
+rm -f "$download_path"
+printf 'old-model' > "$model_path"
+set +e
+DOWNLOAD_FILE_CURL \
+  "https://github.com/vernesong/mihomo/releases/download/LightGBM-Model/Model.bin" \
+  "$download_path" "$model_path" "" "" "" \
+  "$proxy_url" "$proxy_user" "$injected_password"
+download_status=$?
+set -e
+
+[[ "$download_status" == "1" ]]
+[[ "$(cat "$model_path")" == "old-model" ]]
+[[ ! -e "$download_path" ]]
+[[ ! -s "$CURL_CALLS_FILE" ]]
+if grep -F -- "$injected_marker" \
+  "$CURL_ARGS_FILE" "$CURL_CONFIG_FILE" "$CURL_ENV_FILE" "$LOG_FILE" >/dev/null 2>&1; then
+  printf 'FAIL: control characters changed curl configuration or leaked\n' >&2
+  exit 1
+fi
+
+CURL_BEHAVIOR=failure
+: > "$CURL_CALLS_FILE"
+rm -f "$download_path"
+printf 'old-model' > "$model_path"
+set +e
+DOWNLOAD_FILE_CURL \
+  "https://github.com/vernesong/mihomo/releases/download/LightGBM-Model/Model.bin" \
+  "$download_path" "$model_path" "" "" "" "$proxy_url"
+download_status=$?
+set -e
+
+[[ "$download_status" == "1" ]]
+[[ "$(cat "$model_path")" == "old-model" ]]
+[[ ! -e "$download_path" ]]
+[[ "$(wc -l < "$CURL_CALLS_FILE" | tr -d ' ')" == "3" ]]
+
+printf 'openclash_curl proxy tests passed\n'

--- a/tests/openclash_lgbm_flow_test.sh
+++ b/tests/openclash_lgbm_flow_test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LGBM_SCRIPT="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_lgbm.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+run_flow_case() (
+  local scenario="$1"
+  local case_tmp runtime_script target_model
+  local download_status script_status index content
+
+  case_tmp="$(mktemp -d)"
+  runtime_script="$case_tmp/openclash_lgbm.sh"
+  target_model="$case_tmp/etc/openclash/Model.bin"
+  trap 'rm -rf -- "$case_tmp"' EXIT
+  mkdir -p "$case_tmp/etc/openclash" "$case_tmp/tmp/etc/openclash" "$case_tmp/lock"
+
+  sed \
+    -e '/^\. \/lib\/functions\.sh$/d' \
+    -e '/^\. \/usr\/share\/openclash\//d' \
+    -e "s|/tmp/etc/openclash|$case_tmp/tmp/etc/openclash|g" \
+    -e "s|/etc/openclash|$case_tmp/etc/openclash|g" \
+    -e "s|/tmp/Model.bin|$case_tmp/Model.bin|g" \
+    -e "s|/tmp/lock/openclash_lgbm.lock|$case_tmp/lock/openclash_lgbm.lock|g" \
+    "$LGBM_SCRIPT" > "$runtime_script"
+
+  ROUTER_SELF_PROXY=1
+  MIXED_PORT=7893
+  CORE_RUNNING=1
+  DOWNLOAD_CALLS=0
+  RESTART_FLAG=unset
+  LOG_MESSAGES=()
+
+  case "$scenario" in
+    same)
+      DOWNLOAD_RESULTS=(0)
+      DOWNLOAD_CONTENTS=("old-model")
+      EXPECTED_MODEL="old-model"
+      EXPECTED_RESTART=0
+      EXPECTED_CALLS=1
+      ;;
+    not-modified)
+      DOWNLOAD_RESULTS=(2)
+      DOWNLOAD_CONTENTS=("")
+      EXPECTED_MODEL="old-model"
+      EXPECTED_RESTART=0
+      EXPECTED_CALLS=1
+      ;;
+    proxy-update)
+      DOWNLOAD_RESULTS=(1 0)
+      DOWNLOAD_CONTENTS=("" "new-model")
+      EXPECTED_MODEL="new-model"
+      EXPECTED_RESTART=1
+      EXPECTED_CALLS=2
+      ;;
+    failure)
+      DOWNLOAD_RESULTS=(1 1)
+      DOWNLOAD_CONTENTS=("" "")
+      EXPECTED_MODEL="old-model"
+      EXPECTED_RESTART=0
+      EXPECTED_CALLS=2
+      ;;
+    *)
+      fail "unknown scenario: $scenario"
+      ;;
+  esac
+
+  printf 'old-model' > "$target_model"
+
+  uci_get_config() {
+    case "$1" in
+      small_flash_memory) printf '0' ;;
+      lgbm_custom_url) return 0 ;;
+      router_self_proxy) printf '%s' "$ROUTER_SELF_PROXY" ;;
+      mixed_port) printf '%s' "$MIXED_PORT" ;;
+      *) return 1 ;;
+    esac
+  }
+
+  config_load() {
+    [[ "$1" == "openclash" ]]
+  }
+
+  config_foreach() {
+    return 0
+  }
+
+  pidof() {
+    [[ "$1" == "clash" && "$CORE_RUNNING" == "1" ]]
+  }
+
+  DOWNLOAD_FILE_CURL() {
+    index="$DOWNLOAD_CALLS"
+    download_status="${DOWNLOAD_RESULTS[$index]:-1}"
+    content="${DOWNLOAD_CONTENTS[$index]:-}"
+    DOWNLOAD_CALLS=$((DOWNLOAD_CALLS + 1))
+    if [[ "$download_status" == "0" ]]; then
+      printf '%s' "$content" > "$2"
+    fi
+    return "$download_status"
+  }
+
+  LOG_OUT() {
+    LOG_MESSAGES+=("$*")
+  }
+
+  SLOG_CLEAN() {
+    return 0
+  }
+
+  inc_job_counter() {
+    return 0
+  }
+
+  dec_job_counter_and_restart() {
+    RESTART_FLAG="$1"
+  }
+
+  flock() {
+    return 0
+  }
+
+  OPENCLASH_TEST_ONLY=0
+  set +e
+  source "$runtime_script"
+  script_status=$?
+  set -e
+
+  [[ "$script_status" == "0" ]] || fail "$scenario flow returned $script_status"
+  [[ "$(cat "$target_model")" == "$EXPECTED_MODEL" ]] || fail "$scenario changed the model incorrectly"
+  [[ "$RESTART_FLAG" == "$EXPECTED_RESTART" ]] || fail "$scenario produced restart flag $RESTART_FLAG"
+  [[ "$DOWNLOAD_CALLS" == "$EXPECTED_CALLS" ]] || fail "$scenario used $DOWNLOAD_CALLS downloads"
+  [[ ! -e "$case_tmp/Model.bin" ]] || fail "$scenario left the staged model behind"
+)
+
+run_flow_case same
+run_flow_case not-modified
+run_flow_case proxy-update
+run_flow_case failure
+
+printf 'openclash_lgbm flow tests passed\n'

--- a/tests/openclash_lgbm_test.sh
+++ b/tests/openclash_lgbm_test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LGBM_SCRIPT="$REPO_ROOT/luci-app-openclash/root/usr/share/openclash/openclash_lgbm.sh"
+
+OPENCLASH_TEST_ONLY=1 source "$LGBM_SCRIPT"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
+    fail "$message (expected: $expected, actual: $actual)"
+  fi
+}
+
+reset_stubs() {
+  ROUTER_SELF_PROXY=1
+  MIXED_PORT=7893
+  CORE_RUNNING=1
+  AUTH_ENABLED=()
+  AUTH_USERNAME=()
+  AUTH_PASSWORD=()
+  DOWNLOAD_RESULTS=(0)
+  DOWNLOAD_CALLS=0
+  DOWNLOAD_PROXY_ARGS=()
+  LOG_MESSAGES=()
+  TEST_DOWNLOAD_URL="https://github.com/vernesong/mihomo/releases/download/LightGBM-Model/Model.bin"
+}
+
+uci_get_config() {
+  case "$1" in
+    router_self_proxy) printf '%s' "$ROUTER_SELF_PROXY" ;;
+    mixed_port) printf '%s' "$MIXED_PORT" ;;
+    *) return 1 ;;
+  esac
+}
+
+config_load() {
+  [[ "$1" == "openclash" ]]
+}
+
+config_foreach() {
+  local callback="$1"
+  local type="$2"
+  local index
+
+  [[ "$type" == "authentication" ]] || return 0
+  for ((index = 0; index < ${#AUTH_ENABLED[@]}; index++)); do
+    "$callback" "$index"
+  done
+}
+
+config_get_bool() {
+  local variable="$1"
+  local section="$2"
+  local default_value="$4"
+  printf -v "$variable" '%s' "${AUTH_ENABLED[$section]:-$default_value}"
+}
+
+config_get() {
+  local variable="$1"
+  local section="$2"
+  local option="$3"
+  local default_value="$4"
+  local value="$default_value"
+
+  case "$option" in
+    username) value="${AUTH_USERNAME[$section]:-$default_value}" ;;
+    password) value="${AUTH_PASSWORD[$section]:-$default_value}" ;;
+  esac
+  printf -v "$variable" '%s' "$value"
+}
+
+pidof() {
+  [[ "$1" == "clash" && "$CORE_RUNNING" == "1" ]]
+}
+
+LOG_OUT() {
+  LOG_MESSAGES+=("$*")
+}
+
+DOWNLOAD_FILE_CURL() {
+  local result="${DOWNLOAD_RESULTS[$DOWNLOAD_CALLS]:-1}"
+
+  DOWNLOAD_PROXY_ARGS+=("${7-unset}|${8-unset}|${9-unset}")
+  DOWNLOAD_CALLS=$((DOWNLOAD_CALLS + 1))
+  return "$result"
+}
+
+run_download() {
+  set +e
+  download_lgbm_model "$TEST_DOWNLOAD_URL" "/tmp/Model.bin" "/etc/openclash/Model.bin"
+  DOWNLOAD_STATUS=$?
+  set -e
+}
+
+reset_stubs
+assert_eq "http://127.0.0.1:7893" "$(lgbm_proxy_url)" "enabled router proxy should use mixed port"
+
+reset_stubs
+ROUTER_SELF_PROXY=0
+if lgbm_proxy_url >/dev/null; then
+  fail "disabled router-self proxy must not return a fallback URL"
+fi
+
+reset_stubs
+CORE_RUNNING=0
+if lgbm_proxy_url >/dev/null; then
+  fail "stopped core must not return a fallback URL"
+fi
+
+for invalid_port in "" "0" "65536" "not-a-port"; do
+  reset_stubs
+  MIXED_PORT="$invalid_port"
+  if lgbm_proxy_url >/dev/null; then
+    fail "invalid proxy port '$invalid_port' must be rejected"
+  fi
+done
+
+reset_stubs
+DOWNLOAD_RESULTS=(0)
+run_download
+assert_eq "0" "$DOWNLOAD_STATUS" "direct success should be returned"
+assert_eq "1" "$DOWNLOAD_CALLS" "direct success should not retry"
+assert_eq "unset|unset|unset" "${DOWNLOAD_PROXY_ARGS[0]}" "direct attempt must not force a proxy"
+assert_eq "0" "${#LOG_MESSAGES[@]}" "direct success should not log a retry"
+
+reset_stubs
+DOWNLOAD_RESULTS=(2)
+run_download
+assert_eq "2" "$DOWNLOAD_STATUS" "HTTP 304 should be returned"
+assert_eq "1" "$DOWNLOAD_CALLS" "HTTP 304 should not retry"
+
+reset_stubs
+DOWNLOAD_RESULTS=(1 0)
+run_download
+assert_eq "0" "$DOWNLOAD_STATUS" "proxy success should recover a direct failure"
+assert_eq "2" "$DOWNLOAD_CALLS" "direct failure should retry exactly once"
+assert_eq "unset|unset|unset" "${DOWNLOAD_PROXY_ARGS[0]}" "first attempt must remain direct"
+assert_eq "http://127.0.0.1:7893||" "${DOWNLOAD_PROXY_ARGS[1]}" "retry must use the current mixed proxy"
+assert_eq "1" "${#LOG_MESSAGES[@]}" "proxy retry should be visible in the log"
+
+reset_stubs
+AUTH_ENABLED=(0 1)
+AUTH_USERNAME=("disabled" "Clash")
+AUTH_PASSWORD=("disabled" 'p@ss:word\quote"')
+DOWNLOAD_RESULTS=(1 0)
+run_download
+assert_eq "0" "$DOWNLOAD_STATUS" "authenticated proxy should recover a direct failure"
+assert_eq 'http://127.0.0.1:7893|Clash|p@ss:word\quote"' "${DOWNLOAD_PROXY_ARGS[1]}" "retry should use the first complete enabled authentication"
+
+reset_stubs
+TEST_DOWNLOAD_URL="https://example.test/Model.bin"
+DOWNLOAD_RESULTS=(1 0)
+run_download
+assert_eq "1" "$DOWNLOAD_STATUS" "non-GitHub custom URL should preserve direct failure"
+assert_eq "1" "$DOWNLOAD_CALLS" "non-GitHub custom URL should not self-proxy"
+
+reset_stubs
+ROUTER_SELF_PROXY=0
+DOWNLOAD_RESULTS=(1 0)
+run_download
+assert_eq "1" "$DOWNLOAD_STATUS" "disabled router-self proxy should preserve direct failure"
+assert_eq "1" "$DOWNLOAD_CALLS" "disabled router-self proxy should not retry"
+
+reset_stubs
+CORE_RUNNING=0
+DOWNLOAD_RESULTS=(1 0)
+run_download
+assert_eq "1" "$DOWNLOAD_STATUS" "stopped core should preserve direct failure"
+assert_eq "1" "$DOWNLOAD_CALLS" "stopped core should not retry"
+
+reset_stubs
+DOWNLOAD_RESULTS=(1 1)
+run_download
+assert_eq "1" "$DOWNLOAD_STATUS" "proxy failure should remain a failure"
+assert_eq "2" "$DOWNLOAD_CALLS" "proxy failure should stop after one fallback attempt"
+
+printf 'openclash_lgbm tests passed\n'


### PR DESCRIPTION
## Summary

- keep the existing direct LightGBM model download as the first attempt
- retry through the running OpenClash mixed proxy when a direct GitHub download fails and router-self proxy is enabled
- support configured proxy authentication without putting credentials in curl arguments, environment variables, logs, or temporary files
- add focused helper and end-to-end flow regression tests

## Root cause

`openclash_lgbm.sh` only called `DOWNLOAD_FILE_CURL` on the direct network path. Its internal retries therefore repeated the same failing route. On routers where the direct GitHub release-assets connection fails but the local mixed proxy succeeds, the model update could never recover.

The fallback is limited to failed GitHub downloads while the core is running, router-self proxy is enabled, and `mixed_port` is valid. Direct success and HTTP 304 keep the existing behavior, and custom non-GitHub URLs are not sent back through the local proxy.

Proxy credentials are escaped and passed to curl through config stdin. CR/LF values are rejected before curl is started.

## Validation

- `bash -n luci-app-openclash/root/usr/share/openclash/*.sh`
- `bash -n tests/*.sh`
- `dash -n` on the two modified runtime scripts
- `bash tests/openclash_lgbm_test.sh`
- `bash tests/openclash_lgbm_flow_test.sh`
- `bash tests/openclash_curl_proxy_test.sh`
- `git diff --check`
- `cd luci-app-openclash/tools/po2lmo && make clean && make`
- downloaded the current `Model.bin` through the router proxy: 5,243,247 bytes, SHA-256 `0a387160bb34bd552216087dc17ac7135a91bfcf93a2801f5639abbf27adc781`, matching the published release asset

Addresses the LightGBM download part of #5186.
