### PR TITLE
fix: limit router-self IPv6 DNS hijack to loopback

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -1719,7 +1719,7 @@ if [ -n "$FW4" ]; then
             fi
             if [ "$router_self_proxy" = 1 ]; then
                nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
-               nft insert rule inet fw4 nat_output position 0 skgid != 65534 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
+               nft insert rule inet fw4 nat_output position 0 skgid != 65534 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::1} counter redirect to "$DNSPORT" comment \"OpenClash DNS Hijack\"
             fi
          elif [ "$enable_redirect_dns" -eq 2 ]; then
             if [ "$lan_ac_mode" != "1" ]; then
@@ -1740,7 +1740,7 @@ if [ -n "$FW4" ]; then
             nft 'insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 counter jump openclash_dns_redirect'
             if [ "$router_self_proxy" = 1 ]; then
                nft 'add chain inet fw4 nat_output { type nat hook output priority -1; }'
-               nft insert rule inet fw4 nat_output position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::/0} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
+               nft insert rule inet fw4 nat_output position 0 meta nfproto {ipv6} ip6 nexthdr {tcp,udp} th dport 53 ip6 daddr {::1} meta skgid != 65534 counter redirect to "$dns_port" comment \"OpenClash DNS Hijack\"
             fi
          fi
       fi
@@ -2555,8 +2555,8 @@ if [ -z "$FW4" ]; then
                ip6tables -t nat -I PREROUTING -p tcp --dport 53 -m set --match-set lan_ac_white_macs src -j REDIRECT --to-ports "$DNSPORT" -m comment --comment "OpenClash DNS Hijack"
             fi
             if [ "$router_self_proxy" = 1 ]; then
-               ip6tables -t nat -I OUTPUT -p tcp --dport 53 -d ::/0 $noowner -j REDIRECT --to-ports "$DNSPORT" -m comment --comment "OpenClash DNS Hijack"
-               ip6tables -t nat -I OUTPUT -p udp --dport 53 -d ::/0 $noowner -j REDIRECT --to-ports "$DNSPORT" -m comment --comment "OpenClash DNS Hijack"
+               ip6tables -t nat -I OUTPUT -p tcp --dport 53 -d ::1 $noowner -j REDIRECT --to-ports "$DNSPORT" -m comment --comment "OpenClash DNS Hijack"
+               ip6tables -t nat -I OUTPUT -p udp --dport 53 -d ::1 $noowner -j REDIRECT --to-ports "$DNSPORT" -m comment --comment "OpenClash DNS Hijack"
             fi
          elif [ "$enable_redirect_dns" -eq 2 ]; then
             ip6tables -t nat -N openclash_dns_redirect
@@ -2582,8 +2582,8 @@ if [ -z "$FW4" ]; then
             ip6tables -t nat -I PREROUTING -p udp --dport 53 -j openclash_dns_redirect
             ip6tables -t nat -I PREROUTING -p tcp --dport 53 -j openclash_dns_redirect
             if [ "$router_self_proxy" = 1 ]; then
-               ip6tables -t nat -I OUTPUT -p udp --dport 53 -d ::/0 $noowner -j REDIRECT --to-ports "$dns_port" -m comment --comment "OpenClash DNS Hijack"
-               ip6tables -t nat -I OUTPUT -p tcp --dport 53 -d ::/0 $noowner -j REDIRECT --to-ports "$dns_port" -m comment --comment "OpenClash DNS Hijack"
+               ip6tables -t nat -I OUTPUT -p udp --dport 53 -d ::1 $noowner -j REDIRECT --to-ports "$dns_port" -m comment --comment "OpenClash DNS Hijack"
+               ip6tables -t nat -I OUTPUT -p tcp --dport 53 -d ::1 $noowner -j REDIRECT --to-ports "$dns_port" -m comment --comment "OpenClash DNS Hijack"
             fi
          fi
       fi


### PR DESCRIPTION
<!-- Suggested title: fix: limit router-self IPv6 DNS hijack to loopback -->

Fixes #5251

### 问题现象

在 fw4/nftables 环境启用 IPv6、路由本机代理和本地 DNS 劫持后，router-self IPv6 DNS OUTPUT 规则使用：

~~~text
ip6 daddr ::/0
~~~

`::/0` 匹配所有 IPv6 地址，导致路由器本机发往公网 IPv6 DNS 的 TCP/UDP 53 流量被重定向到 dnsmasq/Clash。SmartDNS 等本地解析器使用 IPv6 上游时，可能因此收到 Clash 的 fake-IP。IPv4 对应规则只匹配 `127.0.0.1`，不受影响。

### 根因与历史

提交 [d4cd7436](https://github.com/vernesong/OpenClash/commit/d4cd7436fb7f5484e0368d8a6da4396257156f1c) 的目标是 “dns hijack lo only for router self”，但 IPv6 地址误写为 `::/0`，而不是回环地址 `::1`。

[PR #5209](https://github.com/vernesong/OpenClash/pull/5209) / [73a0cceb](https://github.com/vernesong/OpenClash/commit/73a0cceb21d40f19e88a5f4fa37f102621e4758c) 没有引入该错误；它分离了 IPv4/IPv6 DNS guard，使 IPv6 分支从 0.47.117 起不再被 IPv4 guard 提前跳过，因此暴露了这个旧缺陷。

### 修改

仅修改 `luci-app-openclash/root/etc/init.d/openclash`：

- nftables 两处：`ip6 daddr {::/0}` 改为 `ip6 daddr {::1}`；
- legacy ip6tables 四处：`-d ::/0` 改为 `-d ::1`；
- 覆盖两种 `enable_redirect_dns` 模式及 TCP/UDP；
- 不修改 LAN PREROUTING/DSTNAT 规则。

### 验证

源码检查：

~~~sh
bash -n luci-app-openclash/root/etc/init.d/openclash
git diff --check
~~~

fw4 运行态验证环境：ImmortalWrt 25.12.1、OpenClash 0.47.133、SmartDNS 48-r1、nftables 1.1.6。

~~~text
修复前：规则 ::/0，计数 575 -> 576
         nslookup www.nic.ad.jp 2400:3200::1 -> 198.18.1.88

修复后：规则 ::1，计数 0 -> 0
         nslookup www.nic.ad.jp 2400:3200::1
         -> 192.41.192.145 / 2001:dc2:1000:2006::80:1
~~~

同样的六处替换已写入路由器 `/etc/init.d/openclash` 并重启 OpenClash；服务正常运行，公网 IPv6 DNS 返回真实 A/AAAA，IPv4 DNS 行为未变化。

legacy 运行态验证环境：PVE 隔离 VM、ImmortalWrt 21.02.7 x86/64、firewall3、`ip6tables v1.8.7 (legacy)`，使用隔离 IPv6 DNS stub `fd00:104::254`。

| 场景 | 修复前 | 修复后 |
| --- | --- | --- |
| `enable_redirect_dns=1/2`，公网 IPv6 DNS，UDP/TCP | `::/0` 规则命中，返回 fake-IP | `::1/128` 规则不命中，收到 stub 的 A/AAAA |
| 查询 `::1`，UDP/TCP | — | `::1/128` 各命中一次，仍返回 fake-IP |

### 行为边界

- 依赖 OpenClash 捕获路由器本机直发任意公网 IPv6 DNS 的未记录行为会停止，这是 loopback-only 设计的预期结果。
