### PR TITLE
fix: clean up legacy orphaned clash cores

### DIFF
--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -802,6 +802,30 @@ check_core_status()
    SLOG_CLEAN
 } >/dev/null 2>&1
 
+cleanup_residual_core_processes()
+{
+   local pids pid i
+
+   pids=$(unify_ps_pids "$CLASH")
+   [ -z "$pids" ] && return 0
+
+   # Cores started before the procd exec fix may be reparented to PID 1.
+   # Give them a chance to persist runtime state before forcing termination.
+   for pid in $pids; do
+      kill -15 "$pid" 2>/dev/null || true
+   done
+
+   for i in $(seq 1 5); do
+      sleep 1
+      pids=$(unify_ps_pids "$CLASH")
+      [ -z "$pids" ] && return 0
+   done
+
+   for pid in $pids; do
+      kill -9 "$pid" 2>/dev/null || true
+   done
+}
+
 start_run_core()
 {
    ulimit -SHn 1000000
@@ -3709,6 +3733,7 @@ start_service()
       fi
 
       LOG_OUT "Step 4: Start Running The Clash Core..."
+      cleanup_residual_core_processes
       start_run_core
 
       LOG_OUT "Step 5: Add Cron Rules, Start Daemons..."
@@ -3754,6 +3779,7 @@ stop_service()
       for i in $(seq 1 10); do
          procd_running "openclash" >/dev/null && sleep 1 || break
       done
+      cleanup_residual_core_processes
 
       LOG_OUT "Step 4: Restart Dnsmasq..."
       revert_dnsmasq

--- a/tests/openclash_orphan_cleanup_test.sh
+++ b/tests/openclash_orphan_cleanup_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INIT_SCRIPT="$ROOT_DIR/luci-app-openclash/root/etc/init.d/openclash"
+
+helper="$(
+  awk '
+    /^cleanup_residual_core_processes\(\)$/ { capture = 1 }
+    capture { print }
+    capture && /^}$/ { exit }
+  ' "$INIT_SCRIPT"
+)"
+
+if [[ -z "$helper" ]]; then
+  echo "cleanup_residual_core_processes() not found" >&2
+  exit 1
+fi
+
+eval "$helper"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+CLASH="/etc/openclash/clash"
+scenario=""
+
+reset_case() {
+  scenario="$1"
+  printf '0\n' >"$tmp_dir/calls"
+  : >"$tmp_dir/kills"
+}
+
+unify_ps_pids() {
+  local count
+  count="$(cat "$tmp_dir/calls")"
+  count=$((count + 1))
+  printf '%s\n' "$count" >"$tmp_dir/calls"
+
+  case "$scenario:$count" in
+    graceful:1|graceful:2)
+      printf '101 102\n'
+      ;;
+    stubborn:*)
+      printf '201\n'
+      ;;
+  esac
+}
+
+kill() {
+  printf '%s\n' "$*" >>"$tmp_dir/kills"
+}
+
+sleep() {
+  :
+}
+
+reset_case empty
+cleanup_residual_core_processes
+[[ ! -s "$tmp_dir/kills" ]]
+
+reset_case graceful
+cleanup_residual_core_processes
+grep -qx -- '-15 101' "$tmp_dir/kills"
+grep -qx -- '-15 102' "$tmp_dir/kills"
+if grep -q -- '^-9 ' "$tmp_dir/kills"; then
+  echo "graceful exit unexpectedly used SIGKILL" >&2
+  exit 1
+fi
+
+reset_case stubborn
+cleanup_residual_core_processes
+grep -qx -- '-15 201' "$tmp_dir/kills"
+grep -qx -- '-9 201' "$tmp_dir/kills"
+
+echo "openclash orphan cleanup tests passed"


### PR DESCRIPTION
## Summary

- Clean up legacy Clash core processes that are no longer tracked by procd.
- Run the cleanup unconditionally after `procd_kill` during stop.
- Perform a defensive cleanup immediately before launching a new core, after configuration generation has succeeded, to minimize the traffic interruption window.
- Send `SIGTERM` first, wait up to five seconds, and use `SIGKILL` only for cores that do not exit.
- Keep process matching scoped to the configured `$CLASH` path through `unify_ps_pids`.

## Context

This is a current-`dev` follow-up to #5206 and fixes #5215.

OpenClash 0.47.137 added `exec` to `start_run_core()`, so procd now tracks newly launched Clash cores directly. That prevents new orphans from being created. However, a core orphaned by an older version can survive an upgrade and remain bound to ports 7874/789x/9090 because current `stop_service()` only calls `procd_kill`; procd cannot terminate a pre-existing `PPID=1` core it does not track.

This was independently reproduced in #5215 on x86_64 and ARM64. It also matches the `.136 -> .137` upgrade case: the old core keeps serving traffic while the new procd-managed core cannot acquire any listeners.

Compared with #5206, this version:

- is rebased on 0.47.138 `dev`;
- does not duplicate the already-applied `exec` source fix;
- attempts graceful shutdown before force-killing;
- delays start-side cleanup until the replacement core is ready to launch;
- includes a regression test for empty, graceful, and stubborn-process cases.

The change is intentionally independent from the lifecycle locking/generation work in #5230.

## Tests

- `bash -n luci-app-openclash/root/etc/init.d/openclash`
- `bash -n tests/openclash_orphan_cleanup_test.sh`
- `bash tests/openclash_orphan_cleanup_test.sh`
- `git diff --check`