### PR TITLE
修复低内存时配置文件被清空

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,9 @@
 # Shell scripts (no extension scripts)
 *.sh text eol=lf
 luci-app-openclash/root/etc/init.d/* text eol=lf
+luci-app-openclash/root/etc/uci-defaults/* text eol=lf
+luci-app-openclash/root/etc/config/* text eol=lf
+luci-app-openclash/root/etc/openclash/overwrite/* text eol=lf
 
 # Ruby files
 *.rb text eol=lf

--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -407,7 +407,7 @@ if [ -z "$RAW_CONFIG_FILE" ] || [ ! -f "$RAW_CONFIG_FILE" ]; then
          uci -q commit openclash
          RAW_CONFIG_FILE="/etc/openclash/config/$CONFIG_NAME"
          CONFIG_FILE="/etc/openclash/$CONFIG_NAME"
-         TMP_CONFIG_FILE="/tmp/$CONFIG_NAME"
+         TMP_CONFIG_FILE="/tmp/yaml_config_tmp/$$/$CONFIG_NAME"
          LOG_ERROR "Config Not Found, Switch Config File to【$RAW_CONFIG_FILE】"
          break
       fi
@@ -427,14 +427,18 @@ config_check()
 {
 #创建启动配置
 #rm -rf "/etc/openclash/*.y*" 2>/dev/null
-cp "$RAW_CONFIG_FILE" "$TMP_CONFIG_FILE"
+if ! mkdir -p "${TMP_CONFIG_FILE%/*}" || ! cp "$RAW_CONFIG_FILE" "$TMP_CONFIG_FILE" || [ ! -s "$TMP_CONFIG_FILE" ]; then
+   LOG_ERROR "Create Runtime Config File Failed..."
+   start_fail
+fi
 
 ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "
 begin
-   YAML.load_file('$RAW_CONFIG_FILE');
+   Value = YAML.load_file('$RAW_CONFIG_FILE');
+   raise 'Config root must be a mapping' unless Value.is_a?(Hash);
 rescue Exception => e
    YAML.LOG_ERROR('Unable To Parse Config File,【' + e.message + '】');
-   system 'rm -rf ${TMP_CONFIG_FILE}';
+   exit 1;
 end
 " 2>/dev/null >> $LOG_FILE
 if [ $? -ne 0 ]; then
@@ -809,8 +813,14 @@ start_run_core()
    ulimit -u unlimited
 
    if ! $QUICK_START; then
-      mv "$TMP_CONFIG_FILE" "$CONFIG_FILE"
-      rm -rf "$TMP_CONFIG_FILE"
+      local runtime_config_tmp="${CONFIG_FILE}.tmp.$$"
+      rm -f "$runtime_config_tmp"
+      if ! cp "$TMP_CONFIG_FILE" "$runtime_config_tmp" || [ ! -s "$runtime_config_tmp" ] || ! mv -f "$runtime_config_tmp" "$CONFIG_FILE"; then
+         rm -f "$runtime_config_tmp"
+         LOG_ERROR "Runtime Config Replace Failed, Keep The Existing Config..."
+         start_fail
+      fi
+      rm -f "$TMP_CONFIG_FILE"
    fi
    chown root:root "$CLASH"
    procd_open_instance "openclash"
@@ -3338,7 +3348,7 @@ EOF
                if [ -n "$cfg_name" ]; then
                   age_config_name="${cfg_name%.*}"
                   CONFIG_FILE="/etc/openclash/${cfg_name}"
-                  TMP_CONFIG_FILE="/tmp/${cfg_name}"
+                  TMP_CONFIG_FILE="/tmp/yaml_config_tmp/$$/${cfg_name}"
                fi
             elif printf "%s" "$key_u" | grep -q "^SUB_INFO_URL$"; then
                val_clean=$(printf "%s" "$val" | sed "s/^[[:space:]]*['\"]//;s/['\"][[:space:]]*$//")
@@ -3420,9 +3430,7 @@ EOF
                Value = YAML.load_file('$CONFIG_FILE')
             end
             Overwrite_Value = YAML.overwrite(Value, yaml_data)
-            File.open('$CONFIG_FILE', 'w') do |f|
-               YAML.dump(Overwrite_Value, f)
-            end
+            YAML.dump_file('$CONFIG_FILE', Overwrite_Value)
             File.open('/tmp/yaml_overwrite_marshal', 'wb') { |f| Marshal.dump(Overwrite_Value, f) }
          else
             YAML.LOG_WARN('Invalid YAML Override format, skipped...')
@@ -3450,9 +3458,7 @@ if [ -f "/tmp/yaml_openclash_ruby_parts/$OPENCLASH_OVERWRITE_SID" ]; then
          threads = []
          $ruby_code
          threads.each(&:join)
-         File.open('$CONFIG_FILE', 'w') do |f|
-            YAML.dump(Value, f)
-         end
+         YAML.dump_file('$CONFIG_FILE', Value)
       rescue Exception => e
          YAML.LOG_ERROR('Set Custom Overwrite Script Failed,【%s】' % [e.message])
       end
@@ -3490,7 +3496,7 @@ get_config()
    RAW_CONFIG_FILE=$(uci_get_config "config_path")
    CFG_NAME=$(basename "$RAW_CONFIG_FILE" 2>/dev/null)
    CONFIG_FILE="/etc/openclash/${CFG_NAME}"
-   TMP_CONFIG_FILE="/tmp/${CFG_NAME}"
+   TMP_CONFIG_FILE="/tmp/yaml_config_tmp/$$/${CFG_NAME}"
    CFG_NO_EXT_NAME="${CFG_NAME%.*}"
    SECRET_KEY=$(uci_get_age_secret_keys "$CFG_NO_EXT_NAME")
    OIX_TOKEN=$(uci_get_config "oix_token")
@@ -3622,7 +3628,7 @@ start_service()
       if ! $QUICK_START; then
          LOG_OUT "Step 3: Modify The Config File..."
          config_check
-         /usr/share/openclash/yml_change.sh \
+         if ! /usr/share/openclash/yml_change.sh \
          "$en_mode" "$da_password" "$cn_port" "$proxy_port" "$TMP_CONFIG_FILE" "$ipv6_enable" "$http_port" "$socks_port"\
          "$log_level" "$proxy_mode" "$en_mode_tun" "$stack_type" "$dns_port" "$mixed_port" "$tproxy_port" "$ipv6_dns"\
          "$store_fakeip" "$enable_meta_sniffer" "$enable_geoip_dat" "$geodata_loader" "$enable_meta_sniffer_custom"\
@@ -3631,12 +3637,18 @@ start_service()
          "$enable_respect_rules" "$custom_fakeip_filter_mode" "$iptables_compat" "$disable_quic_go_gso" "$cors_allow"\
          "$geo_custom_url" "$geoip_custom_url" "$geosite_custom_url" "$geoasn_custom_url"\
          "$lgbm_auto_update" "$lgbm_custom_url" "$lgbm_update_interval" "$smart_collect" "$smart_collect_size"\
-         "$fakeip_range6" "$fake_ip_range6_enable" "$global_ua"
+         "$fakeip_range6" "$fake_ip_range6_enable" "$global_ua"; then
+            LOG_ERROR "Config File Overwrite Failed..."
+            start_fail
+         fi
 
-         /usr/share/openclash/yml_rules_change.sh \
+         if ! /usr/share/openclash/yml_rules_change.sh \
          "$enable_custom_clash_rules" "$TMP_CONFIG_FILE"\
          "$enable_rule_proxy" "$router_self_proxy" "$lan_ip" "$enable_redirect_dns" "$en_mode"\
-         "$auto_smart_switch" "$smart_collect" "$smart_collect_rate" "$smart_policy_priority" "$smart_enable_lgbm" "$smart_prefer_asn" "$smart_tolerance"
+         "$auto_smart_switch" "$smart_collect" "$smart_collect_rate" "$smart_policy_priority" "$smart_enable_lgbm" "$smart_prefer_asn" "$smart_tolerance"; then
+            LOG_ERROR "Config File Rules Overwrite Failed..."
+            start_fail
+         fi
 
          #Custom overwrite
          if [ -f "/tmp/yaml_overwrite.sh" ]; then
@@ -3661,9 +3673,7 @@ start_service()
                            threads = []
                            $ruby_code
                            threads.each(&:join)
-                           File.open('$yaml_file', 'w') do |f|
-                              YAML.dump(Value, f)
-                           end
+                           YAML.dump_file('$yaml_file', Value)
                         rescue Exception => e
                            YAML.LOG_ERROR('Set Custom Overwrite Script Failed,【%s】' % [e.message])
                         end
@@ -3679,6 +3689,7 @@ start_service()
             begin
                threads = []
                Value = YAML.load_file('$TMP_CONFIG_FILE')
+               raise 'Config root must be a mapping' unless Value.is_a?(Hash)
                provider_configs = {'proxy-providers' => 'proxy_provider', 'rule-providers' => 'rule_provider'}
                provider_configs.each do |provider_type, path_prefix|
                   if Value.key?(provider_type) && Value[provider_type].is_a?(Hash)
@@ -3699,11 +3710,30 @@ start_service()
                   end
                end
                threads.each(&:join)
-               File.open('$TMP_CONFIG_FILE', 'w') { |f| YAML.dump(Value, f) }
+               YAML.dump_file('$TMP_CONFIG_FILE', Value)
             rescue Exception => e
                YAML.LOG_ERROR('Edit Provider Path Failed,【%s】' % [e.message])
+               exit 1
             end
          " >> $LOG_FILE 2>&1
+         if [ "$?" -ne 0 ]; then
+            LOG_ERROR "Edit Provider Path Failed..."
+            start_fail
+         fi
+
+         ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "
+            begin
+               Value = YAML.load_file('$TMP_CONFIG_FILE')
+               raise 'Config root must be a non-empty mapping' unless Value.is_a?(Hash) && !Value.empty?
+            rescue Exception => e
+               YAML.LOG_ERROR('Runtime Config Validation Failed,【%s】' % [e.message])
+               exit 1
+            end
+         " >> $LOG_FILE 2>&1
+         if [ "$?" -ne 0 ] || [ ! -s "$TMP_CONFIG_FILE" ]; then
+            LOG_ERROR "Runtime Config Validation Failed..."
+            start_fail
+         fi
       else
          LOG_OUT "Step 3: Quick Start Mode, Skip Modify The Config File..."
       fi

--- a/luci-app-openclash/root/etc/openclash/custom/openclash_custom_overwrite.sh
+++ b/luci-app-openclash/root/etc/openclash/custom/openclash_custom_overwrite.sh
@@ -119,7 +119,7 @@ CONFIG_FILE="$1"
     #   rescue Exception => e
     #      puts '${LOGTIME} [error] Set General Failed,【' + e.message + '】';
     #   ensure
-    #      File.open('$CONFIG_FILE','w') {|f| YAML.dump(Value, f)};
+    #      YAML.dump_file('$CONFIG_FILE', Value);
     #   end" 2>/dev/null >> $LOG_FILE
 
 exit 0

--- a/luci-app-openclash/root/usr/share/openclash/YAML.rb
+++ b/luci-app-openclash/root/usr/share/openclash/YAML.rb
@@ -60,20 +60,15 @@ module YAML
 	end
 
 	def self.dump(obj, io = nil, **options)
+		public_key = options.delete(:public)
+		fname = options.delete(:filename)
 		yaml_content = original_dump(obj, **options)
 		processed = yaml_content.include?('short-id:') ? fix_short_id_quotes(yaml_content) : yaml_content
-		public_key = nil
-		fname = nil
-		if options.key?(:public)
-			public_key = options.delete(:public)
-		end
 
 		if (!public_key || public_key.to_s.strip == "")
-			if options.key?(:filename)
-				fname = options.delete(:filename)
-			elsif io && io.respond_to?(:path)
+			if (!fname || fname.to_s.strip == "") && io && io.respond_to?(:path)
 				fname = io.path
-			elsif io && io.respond_to?(:to_path)
+			elsif (!fname || fname.to_s.strip == "") && io && io.respond_to?(:to_path)
 				fname = io.to_path
 			end
 
@@ -114,6 +109,63 @@ module YAML
 		end
 	end
 
+	def self.dump_file(filename, obj, **options)
+		target = filename.to_s
+		raise ArgumentError, "filename is empty" if target.strip.empty?
+
+		content = dump(obj, nil, **options.merge(filename: target))
+		unless content.is_a?(String) && !content.empty?
+			raise "refusing to replace [#{target}] with empty YAML content"
+		end
+
+		# Keep the logical filename for AGE key lookup, but do not replace user-managed symlinks.
+		destination = File.symlink?(target) ? File.realpath(target) : target
+		stat = File.stat(destination) if File.exist?(destination)
+		mode = stat ? stat.mode & 07777 : 0666
+		temporary_base = File.join(
+			File.dirname(destination),
+			".#{File.basename(destination)}.tmp.#{Process.pid}.#{Thread.current.object_id}"
+		)
+		temporary = nil
+
+		begin
+			100.times do |attempt|
+				candidate = "#{temporary_base}.#{attempt}"
+				begin
+					File.open(candidate, File::WRONLY | File::CREAT | File::EXCL, mode) do |file|
+						temporary = candidate
+						file.write(content)
+						file.flush
+						begin
+							file.fsync
+						rescue SystemCallError, NotImplementedError
+						end
+					end
+					break
+				rescue Errno::EEXIST
+					next
+				end
+			end
+			raise "unable to create temporary YAML file for [#{target}]" unless temporary
+
+			raise "temporary YAML file is empty: [#{temporary}]" unless File.size?(temporary)
+
+			if stat
+				begin
+					File.chmod(stat.mode & 07777, temporary)
+					File.chown(stat.uid, stat.gid, temporary)
+				rescue SystemCallError, NotImplementedError
+				end
+			end
+
+			File.rename(temporary, destination)
+		ensure
+			File.delete(temporary) if temporary && File.exist?(temporary)
+		end
+
+		target
+	end
+
 	def self.popen_stream(cmd, input, chunk_size: 64 * 1024)
 		output = String.new
 		IO.popen(cmd, 'r+', err: [:child, :out]) do |io|
@@ -144,10 +196,16 @@ module YAML
 	end
 
 	def self.decode64(input)
-		first_line = input.each_line.find { |l| !l.strip.empty? } || ""
-		return input if !first_line.strip.match?(/\A[A-Za-z0-9+\/=]+\z/)
-		out, status = popen_stream(["base64", "-d"], input)
-		status.success? ? out : input
+		first_line = input.each_line.find { |line| !line.strip.empty? } || ""
+		return input unless first_line.strip.match?(/\A[A-Za-z0-9+\/=]+\z/)
+
+		encoded = input.delete(" \t\r\n")
+		return input if encoded.empty?
+		return input unless encoded.match?(/\A[A-Za-z0-9+\/]+={0,2}\z/)
+		return input if encoded.length % 4 == 1
+
+		out, status = popen_stream(["base64", "-d"], encoded)
+		status.success? && !out.empty? ? out : input
 	rescue Errno::ENOENT
 		input
 	end
@@ -158,18 +216,41 @@ module YAML
 		publics = []
 		secrets = []
 
-		[basename, basename_no_ext].uniq.each do |n|
-			cmd_public = ["/bin/sh", "-c", ". /usr/share/openclash/uci.sh; uci_get_age_public_keys \"$1\"", "sh", n]
-			IO.popen(cmd_public, "r") do |io|
-				io.each_line { |l| publics << l.strip unless l.nil? || l.strip == "" }
-			end
+		names = [basename, basename_no_ext].uniq
+		uci_path = "/etc/config/openclash"
+		return { publics: publics, secrets: secrets } unless File.file?(uci_path)
 
-			cmd_secret = ["/bin/sh", "-c", ". /usr/share/openclash/uci.sh; uci_get_age_secret_keys \"$1\"", "sh", n]
-			IO.popen(cmd_secret, "r") do |io|
-				io.each_line { |l| secrets << l.strip unless l.nil? || l.strip == "" }
+		# Avoid forking /bin/sh while Psych is holding the expanded YAML graph.
+		section_type = nil
+		options = {}
+		flush_section = lambda do
+			if section_type == "config_age_secret" && names.include?(options["name"])
+				publics << options["public"] if options["public"] && !options["public"].empty?
+				secrets << options["secret"] if options["secret"] && !options["secret"].empty?
 			end
 		end
+
+		File.foreach(uci_path, mode: "r:bom|utf-8") do |line|
+			clean = line.strip
+			next if clean.empty? || clean.start_with?("#")
+
+			if match = clean.match(/\Aconfig\s+(['"]?)([^\s'"]+)\1(?:\s+.*)?\z/)
+				flush_section.call
+				section_type = match[2]
+				options = {}
+			elsif section_type && (match = clean.match(/\Aoption\s+([^\s]+)\s+(.+)\z/))
+				value = match[2].strip
+				if value.length >= 2 && ((value.start_with?("'") && value.end_with?("'")) ||
+				                         (value.start_with?('"') && value.end_with?('"')))
+					value = value[1...-1]
+				end
+				options[match[1]] = value
+			end
+		end
+		flush_section.call
 		{ publics: publics, secrets: secrets }
+	rescue SystemCallError, EncodingError
+		{ publics: [], secrets: [] }
 	end
 
 	def self.decrypt_content_with_secret(secret, content)

--- a/luci-app-openclash/root/usr/share/openclash/openclash.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash.sh
@@ -49,7 +49,8 @@ config_test()
 {
    if [ -f "$CLASH" ]; then
       LOG_OUT "Config File Download Successful, Test If There is Any Errors..."
-      test_info=$($CLASH -t -d $CLASH_CONFIG -f "$CFG_FILE" -age-secret-key "$SECRET_KEY")
+      test_info=$($CLASH -t -d "$CLASH_CONFIG" -f "$CFG_FILE" -age-secret-key "$SECRET_KEY" 2>&1)
+      local test_status=$?
       local IFS=$'\n'
       for i in $test_info; do
          if [ -n "$(echo "$i" |grep "configuration file")" ]; then
@@ -59,9 +60,10 @@ config_test()
             echo "$i" >> "$LOG_FILE"
          fi
       done
-      if [ -n "$(echo "$test_info" |grep "test failed")" ]; then
+      if [ "$test_status" -ne 0 ] || [ -n "$(echo "$test_info" |grep "test failed")" ]; then
          return 1
       fi
+      return 0
    else
       return 0
    fi
@@ -113,6 +115,7 @@ config_cus_up()
 	      begin
             threads = [];
 	         Value = YAML.load_file('$CFG_FILE');
+            raise 'Config root must be a mapping' unless Value.is_a?(Hash);
 	         if Value.has_key?('proxies') and not Value['proxies'].to_a.empty? then
 	            Value['proxies'].reverse.each{
 	            |x|
@@ -168,29 +171,60 @@ config_cus_up()
             threads.each(&:join);
 	      rescue Exception => e
 	         YAML.LOG_ERROR('Filter Proxies Failed,【' + e.message + '】');
-	      ensure
-	         begin
-	            File.open('$CFG_FILE','w') {|f| YAML.dump(Value, f)};
-	         rescue Exception => e
-	            YAML.LOG_ERROR('Write file failed:【%s】' % [e.message])
-	         end
-	      end" 2>/dev/null >> $LOG_FILE
+            exit 1;
+	      end
+         begin
+            YAML.dump_file('$CFG_FILE', Value);
+         rescue Exception => e
+            YAML.LOG_ERROR('Write file failed:【%s】' % [e.message]);
+            exit 1;
+         end" 2>/dev/null >> $LOG_FILE || return 1
 	   fi
    fi
+}
+
+config_replace()
+{
+   local config_dir="${CONFIG_FILE%/*}"
+   local config_tmp="$config_dir/.${CONFIG_FILE##*/}.tmp.$$"
+
+   if [ ! -s "$CFG_FILE" ]; then
+      LOG_ERROR "Config File【$name】Is Empty, Keep The Existing Config..."
+      return 1
+   fi
+
+   rm -f "$config_tmp" 2>/dev/null
+   if ! cp "$CFG_FILE" "$config_tmp" 2>/dev/null || [ ! -s "$config_tmp" ] || ! mv -f "$config_tmp" "$CONFIG_FILE" 2>/dev/null; then
+      rm -f "$config_tmp" 2>/dev/null
+      LOG_ERROR "Config File【$name】Replace Failed, Keep The Existing Config..."
+      return 1
+   fi
+
+   rm -f "$CFG_FILE" 2>/dev/null
+   return 0
 }
 
 config_su_check()
 {
    LOG_OUT "Config File Test Successful, Check If There is Any Update..."
    sed -i 's/!<str> /!!str /g' "$CFG_FILE" >/dev/null 2>&1
-   if [ -f "$CONFIG_FILE" ]; then
-      if [ "$only_download" -eq 0 ]; then
-         config_cus_up
+   if [ "$only_download" -eq 0 ]; then
+      if ! config_cus_up || [ ! -s "$CFG_FILE" ]; then
+         LOG_ERROR "Config File【$name】Processing Failed, Keep The Existing Config..."
+         rm -f "$CFG_FILE" 2>/dev/null
+         return 1
       fi
+      if ! config_test; then
+         LOG_ERROR "Config File【$name】Tested Failed After Processing, Keep The Existing Config..."
+         rm -f "$CFG_FILE" 2>/dev/null
+         return 1
+      fi
+   fi
+   if [ -f "$CONFIG_FILE" ]; then
       cmp -s "$CONFIG_FILE" "$CFG_FILE"
       if [ "$?" -ne 0 ]; then
          LOG_OUT "Config File【$name】Are Updates, Start Replacing..."
-         mv "$CFG_FILE" "$CONFIG_FILE" 2>/dev/null
+         config_replace || return 1
          LOG_OUT "Config File【$name】Update Successful!"
       else
          LOG_OUT "Config File【$name】No Change, Do Nothing!"
@@ -199,10 +233,7 @@ config_su_check()
       fi
    else
       LOG_OUT "Config File【$name】Download Successful, Start To Create..."
-      if [ "$only_download" -eq 0 ]; then
-         config_cus_up
-      fi
-      mv "$CFG_FILE" "$CONFIG_FILE" 2>/dev/null
+      config_replace || return 1
       LOG_OUT "Config File【$name】Update Successful!"
    fi
    if [ -z "$CONFIG_PATH" ]; then

--- a/luci-app-openclash/root/usr/share/openclash/ruby.sh
+++ b/luci-app-openclash/root/usr/share/openclash/ruby.sh
@@ -24,7 +24,7 @@ run_ruby_part()
   if [ "$show_error" = "false" ] || [ "$show_error" = "0" ]; then
     ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "begin $part; end" 2>/dev/null
   else
-    ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "begin $part; rescue Exception => e; YAML.LOG_ERROR('Set Custom Overwrite Script Failed,【%s】' % [e.message]); end" 2>/dev/null
+    ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "begin $part; rescue Exception => e; YAML.LOG_ERROR('Set Custom Overwrite Script Failed,【%s】' % [e.message]); exit 1; end" 2>/dev/null
   fi
 }
 
@@ -92,7 +92,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); Value$2=$3; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); Value$2=$3; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -107,7 +107,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if File::exist?('$3') then Value_1 = YAML.load_file('$3'); if not '$4'.empty? then Value$2=Value_1['$4']; else Value$2=Value_1 end else if not '$4'.empty? then Value.delete('$4'); end; end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if File::exist?('$3') then Value_1 = YAML.load_file('$3'); if not '$4'.empty? then Value$2=Value_1['$4']; else Value$2=Value_1 end else if not '$4'.empty? then Value.delete('$4'); end; end; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -122,7 +122,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if File::exist?('$3') then Value_1 = YAML.load_file('$3'); if not Value$2 then Value$2 = {}; end; if Value_1$4 && Value_1$4.is_a?(Hash) then Value$2.merge!(Value_1$4) end end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if File::exist?('$3') then Value_1 = YAML.load_file('$3'); if not Value$2 then Value$2 = {}; end; if Value_1$4 && Value_1$4.is_a?(Hash) then Value$2.merge!(Value_1$4) end end; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -137,7 +137,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 then Value$2=Value$2.uniq; end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 then Value$2=Value$2.uniq; end; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -152,7 +152,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if not Value$2 then Value$2 = {}; end; Value$2.merge!({$3}); File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if not Value$2 then Value$2 = {}; end; Value$2.merge!({$3}); YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -167,7 +167,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if File::exist?('$4') then Value_1 = YAML.load_file('$4'); if not Value$2 or Value$2.nil? then Value$2 = []; end; if Value_1$5 && Value_1$5.is_a?(Array) then idx = [$3.to_i, 0].max; idx = [idx, Value$2.length].min; Value_1$5.reverse.each{|x| Value$2.insert(idx,x); idx += 1}; Value$2=Value$2.uniq end end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if File::exist?('$4') then Value_1 = YAML.load_file('$4'); if not Value$2 or Value$2.nil? then Value$2 = []; end; if Value_1$5 && Value_1$5.is_a?(Array) then idx = [$3.to_i, 0].max; idx = [idx, Value$2.length].min; Value_1$5.reverse.each{|x| Value$2.insert(idx,x); idx += 1}; Value$2=Value$2.uniq end end; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -182,7 +182,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if File::exist?('$3') then Value_1 = YAML.load_file('$3'); if not Value$2 or Value$2.nil? then Value$2 = []; end; if Value_1$4 && Value_1$4.is_a?(Array) then Value$2=(Value_1$4+Value$2).uniq else Value$2=Value$2.uniq end end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if File::exist?('$3') then Value_1 = YAML.load_file('$3'); if not Value$2 or Value$2.nil? then Value$2 = []; end; if Value_1$4 && Value_1$4.is_a?(Array) then Value$2=(Value_1$4+Value$2).uniq else Value$2=Value$2.uniq end end; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -197,7 +197,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if not Value$2 or Value$2.nil? then Value$2 = []; end; idx = [$3.to_i, 0].max; idx = [idx, Value$2.length].min; Value$2=Value$2.insert(idx,'$4').uniq; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if not Value$2 or Value$2.nil? then Value$2 = []; end; idx = [$3.to_i, 0].max; idx = [idx, Value$2.length].min; Value$2=Value$2.insert(idx,'$4').uniq; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -212,7 +212,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if not Value$2 or Value$2.nil? then Value$2 = []; end; idx = [$3.to_i, 0].max; idx = [idx, Value$2.length].min; Value$2=Value$2.insert(idx,$4).uniq; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if not Value$2 or Value$2.nil? then Value$2 = []; end; idx = [$3.to_i, 0].max; idx = [idx, Value$2.length].min; Value$2=Value$2.insert(idx,$4).uniq; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -227,7 +227,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if not Value$2 or Value$2.nil? then Value$2 = []; end; if $4.is_a?(Array) then idx = [$3.to_i, 0].max; idx = [idx, Value$2.length].min; $4.reverse.each{|x| Value$2=Value$2.insert(idx,x); idx += 1}; Value$2=Value$2.uniq end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if not Value$2 or Value$2.nil? then Value$2 = []; end; if $4.is_a?(Array) then idx = [$3.to_i, 0].max; idx = [idx, Value$2.length].min; $4.reverse.each{|x| Value$2=Value$2.insert(idx,x); idx += 1}; Value$2=Value$2.uniq end; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -247,9 +247,9 @@ if openclash_custom_overwrite; then
   return
 fi
 if [ -z "$2" ]; then
-  RUBY_YAML_PARSE="Value = YAML.load_file('$1'); Value.delete('$3'); File.open('$1','w') {|f| YAML.dump(Value, f)}"
+  RUBY_YAML_PARSE="Value = YAML.load_file('$1'); Value.delete('$3'); YAML.dump_file('$1', Value)"
 else
-  RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 then if Value$2.is_a?(Hash) then Value$2.delete('$3') elsif Value$2.is_a?(Array) then Value$2.delete('$3') end end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+  RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 then if Value$2.is_a?(Hash) then Value$2.delete('$3') elsif Value$2.is_a?(Array) then Value$2.delete('$3') end end; YAML.dump_file('$1', Value)"
 fi
 run_ruby_part "$RUBY_YAML_PARSE"
 }
@@ -265,7 +265,7 @@ if openclash_custom_overwrite; then
   write_ruby_part "$RUBY_YAML_PARSE"
   return
 fi
-RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 && Value$2.is_a?(Hash) then if Value$2['$3'] && Value$2['$3'].is_a?(Hash) then Value$2['$3']$4 = '$5' end end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 && Value$2.is_a?(Hash) then if Value$2['$3'] && Value$2['$3'].is_a?(Hash) then Value$2['$3']$4 = '$5' end end; YAML.dump_file('$1', Value)"
 run_ruby_part "$RUBY_YAML_PARSE"
 }
 
@@ -288,9 +288,9 @@ if openclash_custom_overwrite; then
   return
 fi
 if [ -n "$3" ] && [ -n "$4" ] && [ -n "$5" ] && [ -n "$6" ]; then
-  RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 && Value$2.is_a?(Array) then Value$2.map!{|x| if x.is_a?(Hash) && x$3 == '$4' then x$5='$6' end; x}; Value$2.uniq! end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+  RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 && Value$2.is_a?(Array) then Value$2.map!{|x| if x.is_a?(Hash) && x$3 == '$4' then x$5='$6' end; x}; Value$2.uniq! end; YAML.dump_file('$1', Value)"
 elif [ -z "$3" ] && [ -n "$4" ] && [ -z "$5" ] && [ -n "$6" ]; then
-  RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 && Value$2.is_a?(Array) then Value$2.map!{|x| if x == '$4' then '$6' else x end}; Value$2.uniq! end; File.open('$1','w') {|f| YAML.dump(Value, f)}"
+  RUBY_YAML_PARSE="Value = YAML.load_file('$1'); if Value$2 && Value$2.is_a?(Array) then Value$2.map!{|x| if x == '$4' then '$6' else x end}; Value$2.uniq! end; YAML.dump_file('$1', Value)"
 else
   return
 fi

--- a/luci-app-openclash/root/usr/share/openclash/yml_change.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_change.sh
@@ -338,9 +338,10 @@ begin
    else
       Value = YAML.load_file(config_file)
    end
+   raise 'Config root must be a mapping' unless Value.is_a?(Hash)
 rescue Exception => e
    YAML.LOG_ERROR('Load File Failed,【%s】' % [e.message])
-   exit
+   exit 1
 end
 
 begin
@@ -784,7 +785,8 @@ begin
       end
 
       # proxy-server-nameserver
-      local_exclude = (%x{ls -l /sys/class/net/ |awk '{print \$9}'  2>&1}.each_line.map(&:strip) + ['h3=', 'skip-cert-verify=', 'ecs=', 'ecs-override=', 'disable-ipv6=', 'disable-ipv4=', 'disable-qtype-', 'disable-reuse='] + ['utun', 'tailscale0', 'docker0', 'tun163', 'br-lan', 'mihomo']).uniq.join('|')
+      interfaces = Dir.children('/sys/class/net')
+      local_exclude = (interfaces + ['h3=', 'skip-cert-verify=', 'ecs=', 'ecs-override=', 'disable-ipv6=', 'disable-ipv4=', 'disable-qtype-', 'disable-reuse='] + ['utun', 'tailscale0', 'docker0', 'tun163', 'br-lan', 'mihomo']).uniq.join('|')
       non_domain_reg = /^dhcp:\/\/|^system($|:\/\/)|([0-9a-zA-Z-]{1,}\.)+([a-zA-Z]{2,})/
       proxied_server_reg = /^[^#&]+#(?:(?:#{local_exclude})[^&]*&)*(?:(?!(?:#{local_exclude}))[^&]+)/
       servers_to_check = Value.dig('dns', 'nameserver').to_a | Value.dig('dns', 'fallback').to_a | Value.dig('dns', 'default-nameserver').to_a
@@ -818,12 +820,14 @@ begin
    end
 rescue Exception => e
    YAML.LOG_ERROR('Config File Overwrite Failed,【%s】' % [e.message])
-ensure
-   begin
-      File.open(config_file, 'w') { |f| YAML.dump(Value, f) }
-   rescue Exception => e
-      YAML.LOG_ERROR('Write file failed:【%s】' % [e.message])
-   end
-   File.delete('/tmp/yaml_change_marshal') rescue nil
+   exit 1
+end
+
+File.delete('/tmp/yaml_change_marshal') rescue nil
+begin
+   YAML.dump_file(config_file, Value)
+rescue Exception => e
+   YAML.LOG_ERROR('Write file failed:【%s】' % [e.message])
+   exit 1
 end
 " 2>/dev/null >> $LOG_FILE

--- a/luci-app-openclash/root/usr/share/openclash/yml_rules_change.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_rules_change.sh
@@ -15,8 +15,10 @@ yml_other_set()
    ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "
    begin
       Value = YAML.load_file('$2');
+      raise 'Config root must be a mapping' unless Value.is_a?(Hash);
    rescue Exception => e
       YAML.LOG_ERROR('Load File Failed,【' + e.message + '】');
+      exit 1;
    end;
 
    begin
@@ -425,12 +427,14 @@ yml_other_set()
 
    rescue Exception => e
       YAML.LOG_ERROR('Config File Overwrite Failed,【%s】' % [e.message])
-   ensure
-      begin
-         File.open('$2','w') {|f| YAML.dump(Value, f)};
-      rescue Exception => e
-         YAML.LOG_ERROR('Write file failed:【%s】' % [e.message])
-      end
+      exit 1
+   end
+
+   begin
+      YAML.dump_file('$2', Value);
+   rescue Exception => e
+      YAML.LOG_ERROR('Write file failed:【%s】' % [e.message])
+      exit 1
    end" 2>/dev/null >> $LOG_FILE
 }
 


### PR DESCRIPTION
## 问题说明

修复 #5192 中配置处理失败后运行配置文件被清空的问题。

在内存紧张的 OpenWrt 设备上，Ruby 处理 YAML 时启动额外的 `/bin/sh` 可能失败，随后旧逻辑仍以写模式打开目标文件，最终将配置截断为 0 字节，并引发 `key? for false`、`has_key? for false` 等连锁错误。

## 修复内容

- YAML 先在内存中完成序列化，再写入同目录临时文件并原子替换目标文件；写入失败时保留原配置。
- 配置处理失败时立即终止启动流程，避免继续使用无效配置。
- 使用 Ruby 直接读取网卡目录，移除 `ls | awk` Shell 子进程。
- 使用 Ruby 直接读取 AGE 的 UCI 配置，移除最终写回阶段额外的 `/bin/sh`。
- 调整临时配置的提升与清理流程，避免失败产物覆盖有效配置。

## 实机验证

- 架构：ARMv8 Processor rev 4
- 平台：qualcommax/ipq807x
- 固件：OpenWrt 25.12.5 r33051-f5dae5ece4
- LuCI：openwrt-25.12 branch 26.187.49110~99464ec
- 内核：6.12.94
- OpenClash：0.47.140（dev）
- 原始配置约 583 KB，无 Swap

已使用对应 OpenWrt 25.12.5 SDK 构建 APK 并在上述设备安装验证，配置生成及启动恢复正常，失败时也不会再将现有 YAML 截断为空文件。