### PR TITLE
fix(watchdog): use ip link show instead of ip tuntap for busybox comp…

### DIFF
--- a/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh
+++ b/luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh
@@ -244,7 +244,7 @@ fi
          LOG_WATCHDOG "Setting Firewall For Rules Order..."
          /etc/init.d/openclash reload "firewall"
          let FIREWALL_RELOAD++
-      elif [ -n "$(ip tuntap list |grep utun)" ] && [ -z "$(ip route list table 354)" ]; then
+      elif [ -n "$(ip link show utun 2>/dev/null)" ] && [ -z "$(ip route list table 354)" ]; then
          ## 路由表检查
          LOG_WATCHDOG "Setting Firewall For IP Rules Table Recreate..."
          /etc/init.d/openclash reload "firewall"


### PR DESCRIPTION
## Summary

BusyBox `ip` (default on OpenWrt) does not support the `tuntap` subcommand — only the optional `ip-full` package provides it. When `ip tuntap list` fails silently, the watchdog skips the table 354 route check entirely, causing IPv4 traffic to bypass TPROXY/fake-ip routing.

## Symptoms

When routing table 354 gets out of sync (e.g., after an interface flap or firewall reload), the watchdog is supposed to detect the missing table and trigger a firewall reload to restore TPROXY routing. Instead:

- `ip tuntap list` returns empty (BusyBox `ip` doesn't recognize `tuntap`)
- The `elif` condition evaluates to false
- Table 354 check is never reached
- **All IPv4 traffic on proxied devices bypasses Clash entirely** — essentially a silent proxy bypass
- No error logged; everything looks normal except traffic isn't being routed through the proxy

## Root Cause

OpenWrt's BusyBox `ip` only supports these objects:

```
ip address|route|link|neigh|rule [ARGS]
```

The `tuntap` subcommand requires the full `iproute2` package (`ip-full`), which is listed as a recommended dependency but not strictly enforced:

```bash
root@OpenWrt:~# ip tuntap list
ip: tuntap: unknown object
```

The watchdog's current check on line 247:

```bash
elif [ -n "$(ip tuntap list |grep utun)" ] && [ -z "$(ip route list table 354)" ]; then
```

When `ip tuntap list` outputs nothing (command not found on BusyBox), `[ -n "" ]` is false, so the entire condition short-circuits — table 354 is never checked.

## Fix

One-line change in `luci-app-openclash/root/usr/share/openclash/openclash_watchdog.sh`:

```diff
-      elif [ -n "$(ip tuntap list |grep utun)" ] && [ -z "$(ip route list table 354)" ]; then
+      elif [ -n "$(ip link show utun 2>/dev/null)" ] && [ -z "$(ip route list table 354)" ]; then
```

**Why `ip link show utun`:**

- Supported by both BusyBox `ip` and `ip-full` — no dependency on optional packages
- Semantically cleaner — we only need to know if the `utun` TUN interface exists, not enumerate all tuntap devices
- `2>/dev/null` silences "Device not found" error when utun is absent, keeping the condition semantics identical to the original

## Reproduction

1. Deploy OpenClash with TUN mode on OpenWrt (without `ip-full` installed — the default)
2. Trigger a routing table desync (e.g., restart OpenClash, flap the WAN interface, or manually `ip route flush table 354`)
3. Observe: watchdog runs `ip tuntap list` → empty output → skips table 354 check
4. Result: IPv4 traffic on proxied devices bypasses Clash entirely (DIRECT instead of TPROXY)

## Environment

- OpenWrt 24.10.2 (rockchip/armv8, FriendlyWrt on NanoPi R5S)
- BusyBox v1.36.1
- `ip-full` NOT installed (using default BusyBox `ip`)

## Additional Notes

OpenClash's installation guide does recommend `ip-full` as a dependency, but it's not strictly enforced by the package manager, and many OpenWrt builds ship without it. Since the fix is trivial and works universally, it's better to avoid the dependency on an optional package rather than require users to install it.