### PR TITLE
fix: improve external dashboard access

### DIFF
--- a/luci-app-openclash/luasrc/controller/openclash.lua
+++ b/luci-app-openclash/luasrc/controller/openclash.lua
@@ -168,16 +168,24 @@ local function dase()
 	return fs.uci_get_config("config", "dashboard_password")
 end
 
-local function db_foward_domain()
+local function dashboard_forward_domain()
 	return fs.uci_get_config("config", "dashboard_forward_domain")
 end
 
-local function db_foward_port()
+local function dashboard_forward_port()
 	return fs.uci_get_config("config", "dashboard_forward_port")
 end
 
-local function db_foward_ssl()
+local function dashboard_forward_ssl()
 	return fs.uci_get_config("config", "dashboard_forward_ssl") or 0
+end
+
+local function dashboard_custom_url()
+	return fs.uci_get_config("config", "dashboard_custom_url")
+end
+
+local function dashboard_custom_clash_compatible()
+	return fs.uci_get_config("config", "dashboard_custom_clash_compatible") or 0
 end
 
 local function coremodel()
@@ -1481,8 +1489,10 @@ function action_conn_status(internal)
 		clash = uci:get("openclash", "config", "enable") == "1",
 		daip = daip(),
 		dase = dase(),
-		db_foward_port = db_foward_port(),
-		db_foward_domain = db_foward_domain(),
+		-- Keep the misspelled JSON keys for compatibility with existing views.
+		db_foward_port = dashboard_forward_port(),
+		db_foward_domain = dashboard_forward_domain(),
+		db_forward_ssl = dashboard_forward_ssl(),
 		cn_port = cn_port()
 	}
 	if internal then return data end
@@ -1503,7 +1513,9 @@ function action_status()
 		dase = status_data.dase,
 		db_foward_port = status_data.db_foward_port,
 		db_foward_domain = status_data.db_foward_domain,
-		db_forward_ssl = db_foward_ssl(),
+		db_forward_ssl = status_data.db_forward_ssl,
+		dashboard_custom_url = dashboard_custom_url(),
+		dashboard_custom_clash_compatible = dashboard_custom_clash_compatible(),
 		cn_port = status_data.cn_port,
 		yacd = fs.isdirectory("/usr/share/openclash/ui/yacd"),
 		dashboard = fs.isdirectory("/usr/share/openclash/ui/dashboard"),

--- a/luci-app-openclash/luasrc/model/cbi/openclash/settings.lua
+++ b/luci-app-openclash/luasrc/model/cbi/openclash/settings.lua
@@ -1272,7 +1272,7 @@ o.description = translate("Set Dashboard Secret")
 o = s:taboption("dashboard", Value, "dashboard_forward_domain")
 o.title = translate("Public Dashboard Address")
 o.datatype = "or(host, string)"
-o.placeholder = "example.com"
+o.placeholder = "example.com or 192.168.1.1 or [2001:db8::1]"
 o.rmempty = true
 o.description = translate("Domain Name or IP For Dashboard Login From Public Network (without http:// or https://)")
 function o.validate(self, value)
@@ -1312,7 +1312,7 @@ o.description = translate("Is SSL enabled For Dashboard Login From Public Networ
 
 o = s:taboption("dashboard", Value, "dashboard_custom_url")
 o.title = translate("Custom Dashboard URL")
-o.placeholder = "https://board.example.com/"
+o.placeholder = "https://board.example.com/ or http://192.168.1.1:9090 or https://[2001:db8::1]:8443"
 o.rmempty = true
 o.description = translate("Optional complete HTTP(S) URL for an externally hosted Dashboard. OpenClash appends hostname, port and secret parameters without adding a local UI path. Include a hash route such as #/setup in the URL when required by the panel.")
 function o.validate(self, value)

--- a/luci-app-openclash/luasrc/model/cbi/openclash/settings.lua
+++ b/luci-app-openclash/luasrc/model/cbi/openclash/settings.lua
@@ -1274,18 +1274,81 @@ o.title = translate("Public Dashboard Address")
 o.datatype = "or(host, string)"
 o.placeholder = "example.com"
 o.rmempty = true
-o.description = translate("Domain Name For Dashboard Login From Public Network")
+o.description = translate("Domain Name or IP For Dashboard Login From Public Network (without http:// or https://)")
+function o.validate(self, value)
+	if value == nil or value == "" then
+		return value
+	end
+	value = value:match("^%s*(.-)%s*$"):gsub("^[Hh][Tt][Tt][Pp][Ss]?://", "")
+	if value:find("/", 1, true) or value:find("@", 1, true) or value:find("?", 1, true) or value:find("#", 1, true) or value:find("\\", 1, true) or value:match("%s") then
+		return nil, translate("Enter a valid hostname or IP address without a path or user information")
+	end
+	local host, port = value:match("^%[([^%]]+)%]:(%d+)$")
+	if not host then
+		host = value:match("^%[([^%]]+)%]$")
+	end
+	if not host then
+		host, port = value:match("^([^:]+):(%d+)$")
+	end
+	if not host then
+		host = value:match("^([^:]+)$")
+	end
+	if not host or not datatype.host(host) or (port and (tonumber(port) < 1 or tonumber(port) > 65535)) then
+		return nil, translate("Enter a valid hostname or IP address without a path or user information")
+	end
+	return value
+end
 
 o = s:taboption("dashboard", Value, "dashboard_forward_port")
 o.title = translate("Public Dashboard Port")
 o.datatype = "port"
 o.rmempty = true
-o.description = translate("Port For Dashboard Login From Public Network")
+o.description = translate("Optional Port For Dashboard Login From Public Network (defaults to 443 with SSL or 80 without SSL)")
 
 o = s:taboption("dashboard", Flag, "dashboard_forward_ssl")
 o.title = translate("Public Dashboard SSL enabled")
 o.default = 0
 o.description = translate("Is SSL enabled For Dashboard Login From Public Network")
+
+o = s:taboption("dashboard", Value, "dashboard_custom_url")
+o.title = translate("Custom Dashboard URL")
+o.placeholder = "https://board.example.com/"
+o.rmempty = true
+o.description = translate("Optional complete HTTP(S) URL for an externally hosted Dashboard. OpenClash appends hostname, port and secret parameters without adding a local UI path. Include a hash route such as #/setup in the URL when required by the panel.")
+function o.validate(self, value)
+	if value == nil or value == "" then
+		return value
+	end
+	value = value:match("^%s*(.-)%s*$")
+	local scheme, authority = value:match("^([Hh][Tt][Tt][Pp][Ss]?)://([^/%?#]+)")
+	local without_escapes = value:gsub("%%[0-9a-fA-F][0-9a-fA-F]", "")
+	if not scheme or not authority or authority:find("@", 1, true) or value:find("\\", 1, true) or value:match("[%c%s]") or value:match('[<>"{}|^`]') or value:match("[\128-\255]") or without_escapes:find("%%", 1, true) then
+		return nil, translate("Enter a valid complete HTTP or HTTPS URL without user information")
+	end
+	local host, port = authority:match("^%[([^%]]+)%]:(%d+)$")
+	if not host then
+		host = authority:match("^%[([^%]]+)%]$")
+	end
+	if not host then
+		host, port = authority:match("^([^:]+):(%d+)$")
+	end
+	if not host then
+		host = authority:match("^([^:]+)$")
+	end
+	if not host or not datatype.host(host) then
+		return nil, translate("Enter a valid complete HTTP or HTTPS URL without user information")
+	end
+	if port and (tonumber(port) < 1 or tonumber(port) > 65535) then
+		return nil, translate("Enter a valid complete HTTP or HTTPS URL without user information")
+	end
+	return value
+end
+
+o = s:taboption("dashboard", Flag, "dashboard_custom_clash_compatible")
+o.title = translate("Clash Dashboard Compatibility Mode")
+o.default = 0
+o.rmempty = false
+o.description = translate("Use Clash Dashboard-compatible #/?host=... login parameters for the custom Dashboard URL instead of the standard hostname parameters.")
 
 o = s:taboption("dashboard", DummyValue, "Dashboard", translate("Switch(Update) Dashboard Version"))
 o.template="openclash/switch_dashboard"

--- a/luci-app-openclash/luasrc/view/openclash/log.htm
+++ b/luci-app-openclash/luasrc/view/openclash/log.htm
@@ -337,24 +337,9 @@ function coreLogWebSocket() {
             return;
         }
 
-        var protocol = window.location.protocol === "https:" ? "wss://" : "ws://";
-        var host, port;
-
-        if (status.daip && window.location.hostname === status.daip) {
-            host = status.daip;
-            port = status.cn_port;
-        } else if (status.daip && window.location.hostname !== status.daip && 
-                   status.db_foward_domain && status.db_foward_port) {
-            host = status.db_foward_domain;
-            port = status.db_foward_port;
-        } else {
-            host = status.daip;
-            port = status.cn_port;
-        }
-
         var token = status.dase;
         var level = currentLogLevel;
-        var wsUrl = protocol + host + ":" + port + "/logs?token=" + token + "&level=" + level;
+        var wsUrl = ocGetDashboardWebSocketOrigin(status) + "/logs?token=" + encodeURIComponent(token || "") + "&level=" + encodeURIComponent(level);
 
         try {
             coreWebSocket = new WebSocket(wsUrl);

--- a/luci-app-openclash/luasrc/view/openclash/status.htm
+++ b/luci-app-openclash/luasrc/view/openclash/status.htm
@@ -292,6 +292,7 @@
                                     <button class="dashboard-btn" id="_webm"><%:Collecting data...%></button>
                                     <button class="dashboard-btn" id="_webz"><%:Collecting data...%></button>
                                     <button class="dashboard-btn" id="_webo"><%:Collecting data...%></button>
+                                    <button class="dashboard-btn hidden" id="_web_external"><%:Collecting data...%></button>
                                 </div>
                             </div>
                         </div>
@@ -411,6 +412,7 @@
         webo: document.getElementById('_webo'),
         webm: document.getElementById('_webm'),
         webz: document.getElementById('_webz'),
+        web_external: document.getElementById('_web_external'),
         daip: document.getElementById('_daip'),
         oclog: document.getElementById('_oclog'),
         close_all_connection: document.getElementById('_close_all_connection_btn'),
@@ -447,7 +449,9 @@
     };
 
     var getDashboardBaseURL = ocGetDashboardBaseURL;
+    var getDashboardWebSocketOrigin = ocGetDashboardWebSocketOrigin;
     var buildDashboardURL = ocBuildDashboardURL;
+    var buildExternalDashboardURL = ocBuildExternalDashboardURL;
     var bytesToSize = ocFormatBytes;
     var debounceButton = ocDebounce;
 
@@ -3679,6 +3683,9 @@
             var webzContent = status.clash ? '<input type="button" class="dashboard-btn" value="<%:Zashboard%>" onclick="return net_zashboard(this)"/>' : '<input type="button" class="dashboard-btn" value="<%:Zashboard%>" onclick="event.preventDefault(); event.stopPropagation(); return false;"/>';
             updates.push({element: DOMCache.webz, content: webzContent});
 
+            var externalWebContent = status.clash ? '<input type="button" class="dashboard-btn" value="<%:External Dashboard%>" onclick="return external_dashboard(this)"/>' : '<input type="button" class="dashboard-btn" value="<%:External Dashboard%>" onclick="event.preventDefault(); event.stopPropagation(); return false;"/>';
+            updates.push({element: DOMCache.web_external, content: externalWebContent});
+
             var closeConnContent = status.clash ? '<input type="button" class="dashboard-btn" value="<%:Close Connect%>" onclick="return b_close_all_connection(this)"/>' : '<input type="button" class="dashboard-btn" value="<%:Close Connect%>" onclick="event.preventDefault(); event.stopPropagation(); return false;"/>';
             updates.push({element: document.getElementById('_close_all_connection_btn'), content: closeConnContent});
 
@@ -3709,21 +3716,16 @@
                 DOMCache.webz.classList.add('hidden');
             }
 
+            DOMCache.web_external.classList.toggle('hidden', !ocGetCustomDashboardURL(status));
+
             StateManager.current_status = status;
 
             if (status.daip) {
                 var daipContent, dapoContent;
 
-                if (status.daip && window.location.hostname == status.daip) {
-                    dapoContent = status.cn_port ? ":"+status.cn_port : "";
-                    daipContent = status.daip ? "<b style=color:var(--success-color)>"+status.daip+dapoContent+"</b>" : "<b style=color:var(--error-color)>"+"<%:Not Set%>"+"</b>";
-                } else if (status.daip && window.location.hostname != status.daip && status.db_foward_domain && status.db_foward_port) {
-                    dapoContent = status.db_foward_port ? ":"+status.db_foward_port : "";
-                    daipContent = status.db_foward_domain ? "<b style=color:var(--success-color)>"+status.db_foward_domain+dapoContent+"</b>" : "<b style=color:var(--error-color)>"+"<%:Not Set%>"+"</b>";
-                } else {
-                    dapoContent = status.cn_port ? ":"+status.cn_port : "";
-                    daipContent = status.daip ? "<b style=color:var(--success-color)>"+status.daip+dapoContent+"</b>" : "<b style=color:var(--error-color)>"+"<%:Not Set%>"+"</b>";
-                }
+                var dashboardBase = getDashboardBaseURL(status);
+                dapoContent = dashboardBase.port ? ":" + dashboardBase.port : "";
+                daipContent = "<b style=color:var(--success-color)>" + dashboardBase.host + dapoContent + "</b>";
 
                 DOMCache.daip.innerHTML = daipContent;   
 
@@ -3853,29 +3855,10 @@
             return false;
         }
 
-        StatsWSMeta.protocol = getWebSocketProtocol(status);
+        StatsWSMeta.protocol = getDashboardWebSocketOrigin(status);
         StatsWSMeta.token = status.dase;
         syncDataSource();
         return true;
-    }
-
-    function getWebSocketProtocol(status) {
-        var protocol = window.location.protocol === "https:" ? "wss://" : "ws://";
-        var host, port;
-
-        if (status.daip && window.location.hostname === status.daip) {
-            host = status.daip;
-            port = status.cn_port;
-        } else if (status.daip && window.location.hostname !== status.daip && 
-                   status.db_foward_domain && status.db_foward_port) {
-            host = status.db_foward_domain;
-            port = status.db_foward_port;
-        } else {
-            host = status.daip;
-            port = status.cn_port;
-        }
-
-        return protocol + host + ":" + port;
     }
 
     function AnnouncementAnimator(config) {
@@ -4416,6 +4399,17 @@
         return false;
     }
 
+    function external_dashboard(btn) {
+        btn.disabled = true;
+        btn.value = '<%:External Dashboard%>';
+        var status = StateManager.current_status;
+        if (!status) { setTimeout(function() { external_dashboard(btn); }, 500); return false; }
+        var url = buildExternalDashboardURL(status);
+        if (url) winOpen(url);
+        btn.disabled = false;
+        return false;
+    }
+
     function homepage() {
         winOpen('https://github.com/vernesong/OpenClash');
     }
@@ -4566,28 +4560,18 @@
     }
 
     function copyAddress() {
+        var currentStatus = StateManager.current_status;
+        var externalURL = currentStatus ? buildExternalDashboardURL(currentStatus) : '';
+        if (externalURL) {
+            ocCopyToClipboard(externalURL, DOMCache.copy_address, '<%:Control panel address copied:%> ', '<%:Copy failed, please copy manually:%>');
+            return false;
+        }
+
         XHR.get('<%=luci.dispatcher.build_url("admin", "services", "openclash", "dashboard_type")%>', null, function(x, status) {
             if (x && x.status == 200) {
                 var panel = status.default_dashboard;
                 if (panel && StateManager.current_status[panel]) {
-                    var url;
-                    var currentStatus = StateManager.current_status;
-                    if (currentStatus.daip && window.location.hostname == currentStatus.daip) {
-                        url = 'http://' + window.location.hostname + ':' + currentStatus.cn_port + '/ui/' + panel;
-                    } else if (currentStatus.daip && window.location.hostname != currentStatus.daip && currentStatus.db_foward_domain && currentStatus.db_foward_port) {
-                        var ui_proto = currentStatus.db_forward_ssl == 0 ? 'http://' : 'https://';
-                        url = ui_proto + currentStatus.db_foward_domain + ':' + currentStatus.db_foward_port + '/ui/' + panel;
-                    } else {
-                        url = 'http://' + window.location.hostname + ':' + currentStatus.cn_port + '/ui/' + panel;
-                    }
-
-                    if (panel === 'zashboard' || panel === 'metacubexd') {
-                        url += '/#/setup?hostname=' + (currentStatus.daip && window.location.hostname == currentStatus.daip ? window.location.hostname : (currentStatus.db_foward_domain || window.location.hostname)) + '&port=' + (currentStatus.daip && window.location.hostname == currentStatus.daip ? currentStatus.cn_port : (currentStatus.db_foward_port || currentStatus.cn_port)) + (currentStatus.dase ? '&secret=' + currentStatus.dase : '');
-                    } else if (panel === 'yacd') {
-                        url += '/?hostname=' + (currentStatus.daip && window.location.hostname == currentStatus.daip ? window.location.hostname : (currentStatus.db_foward_domain || window.location.hostname)) + '&port=' + (currentStatus.daip && window.location.hostname == currentStatus.daip ? currentStatus.cn_port : (currentStatus.db_foward_port || currentStatus.cn_port)) + (currentStatus.dase ? '&secret=' + currentStatus.dase : '');
-                    } else if (panel === 'dashboard') {
-                        url += '/#/?host=' + (currentStatus.daip && window.location.hostname == currentStatus.daip ? window.location.hostname : (currentStatus.db_foward_domain || window.location.hostname)) + '&port=' + (currentStatus.daip && window.location.hostname == currentStatus.daip ? currentStatus.cn_port : (currentStatus.db_foward_port || currentStatus.cn_port)) + (currentStatus.dase ? '&secret=' + currentStatus.dase : '');
-                    }
+                    var url = buildDashboardURL(currentStatus, panel, panel === 'zashboard' || panel === 'metacubexd');
 
                     ocCopyToClipboard(url, DOMCache.copy_address, '<%:Control panel address copied:%> ', '<%:Copy failed, please copy manually:%>');
                 } else {

--- a/luci-app-openclash/po/es/openclash.es.po
+++ b/luci-app-openclash/po/es/openclash.es.po
@@ -501,17 +501,44 @@ msgstr "Dirección pública del panel"
 msgid "Domain Name For Dashboard Login From Public Network"
 msgstr "Dominio para iniciar sesión en el panel desde Internet"
 
+msgid "Domain Name or IP For Dashboard Login From Public Network (without http:// or https://)"
+msgstr "Dominio o IP para iniciar sesión en el panel desde Internet (sin http:// ni https://)"
+
+msgid "Enter a valid hostname or IP address without a path or user information"
+msgstr "Introduzca un nombre de host o dirección IP válidos sin ruta ni información de usuario"
+
 msgid "Public Dashboard Port"
 msgstr "Puerto público del panel"
 
 msgid "Port For Dashboard Login From Public Network"
 msgstr "Puerto usado para iniciar sesión en el panel desde Internet"
 
+msgid "Optional Port For Dashboard Login From Public Network (defaults to 443 with SSL or 80 without SSL)"
+msgstr "Puerto opcional para iniciar sesión en el panel desde Internet (predeterminado: 443 con SSL o 80 sin SSL)"
+
 msgid "Public Dashboard SSL enabled"
 msgstr "Habilitar SSL para acceso público"
 
 msgid "Is SSL enabled For Dashboard Login From Public Network"
 msgstr "Indica si el acceso al panel desde Internet utiliza SSL"
+
+msgid "Custom Dashboard URL"
+msgstr "URL personalizada del panel"
+
+msgid "Optional complete HTTP(S) URL for an externally hosted Dashboard. OpenClash appends hostname, port and secret parameters without adding a local UI path. Include a hash route such as #/setup in the URL when required by the panel."
+msgstr "URL HTTP(S) completa opcional de un panel alojado externamente. OpenClash añade los parámetros hostname, port y secret sin añadir una ruta de interfaz local. Incluya una ruta hash como #/setup en la URL cuando el panel lo requiera."
+
+msgid "External Dashboard"
+msgstr "Panel externo"
+
+msgid "Clash Dashboard Compatibility Mode"
+msgstr "Modo de compatibilidad de Clash Dashboard"
+
+msgid "Use Clash Dashboard-compatible #/?host=... login parameters for the custom Dashboard URL instead of the standard hostname parameters."
+msgstr "Use parámetros de inicio de sesión compatibles con Clash Dashboard #/?host=... para la URL del panel personalizado en lugar de los parámetros hostname estándar."
+
+msgid "Enter a valid complete HTTP or HTTPS URL without user information"
+msgstr "Introduzca una URL HTTP o HTTPS completa válida sin información de usuario"
 
 msgid "GEO Update"
 msgstr "Actualización de bases GEO"

--- a/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
+++ b/luci-app-openclash/po/zh-cn/openclash.zh-cn.po
@@ -503,17 +503,44 @@ msgstr "管理页面公网域名"
 msgid "Domain Name For Dashboard Login From Public Network"
 msgstr "设置公网域名，便于从公网访问时自动登录"
 
+msgid "Domain Name or IP For Dashboard Login From Public Network (without http:// or https://)"
+msgstr "设置用于公网访问的域名或 IP，请勿填写 http:// 或 https:// 协议头"
+
+msgid "Enter a valid hostname or IP address without a path or user information"
+msgstr "请输入不带路径或用户信息的有效主机名或 IP 地址"
+
 msgid "Public Dashboard Port"
 msgstr "管理页面映射端口"
 
 msgid "Port For Dashboard Login From Public Network"
 msgstr "设置映射端口，便于从公网访问时自动登录"
 
+msgid "Optional Port For Dashboard Login From Public Network (defaults to 443 with SSL or 80 without SSL)"
+msgstr "可选的公网映射端口；启用 SSL 时默认为 443，未启用时默认为 80"
+
 msgid "Public Dashboard SSL enabled"
 msgstr "管理页面公网 SSL 访问"
 
 msgid "Is SSL enabled For Dashboard Login From Public Network"
 msgstr "设置公网协议是否开启了 SSL，便于从公网访问时自动登录"
+
+msgid "Custom Dashboard URL"
+msgstr "自定义 Dashboard URL"
+
+msgid "Optional complete HTTP(S) URL for an externally hosted Dashboard. OpenClash appends hostname, port and secret parameters without adding a local UI path. Include a hash route such as #/setup in the URL when required by the panel."
+msgstr "可选的外部 Dashboard 完整 HTTP(S) URL。OpenClash 会追加 hostname、port 和 secret 参数，不会添加本地 UI 路径；如果面板需要 Hash 路由，请在 URL 中包含类似 #/setup 的路由。"
+
+msgid "External Dashboard"
+msgstr "外部面板"
+
+msgid "Clash Dashboard Compatibility Mode"
+msgstr "Clash Dashboard 兼容模式"
+
+msgid "Use Clash Dashboard-compatible #/?host=... login parameters for the custom Dashboard URL instead of the standard hostname parameters."
+msgstr "为自定义 Dashboard URL 使用 Clash Dashboard 兼容的 #/?host=... 登录参数，而不是标准的 hostname 参数。"
+
+msgid "Enter a valid complete HTTP or HTTPS URL without user information"
+msgstr "请输入不包含用户信息的有效完整 HTTP 或 HTTPS URL"
 
 msgid "GEO Update"
 msgstr "GEO 数据库订阅"
@@ -4388,4 +4415,3 @@ msgstr "版本号"
 
 msgid "to update individually"
 msgstr "则独立更新"
-

--- a/luci-app-openclash/root/usr/share/openclash/yml_change.sh
+++ b/luci-app-openclash/root/usr/share/openclash/yml_change.sh
@@ -23,6 +23,9 @@ fake_ip_filter_mode=${34}
 default_dashboard=$(uci_get_config "default_dashboard" || echo "metacubexd")
 yacd_type=$(uci_get_config "yacd_type" || echo "Official")
 dashboard_type=$(uci_get_config "dashboard_type" || echo "Official")
+dashboard_forward_port=$(uci_get_config "dashboard_forward_port" || echo 0)
+dashboard_forward_ssl=$(uci_get_config "dashboard_forward_ssl" || echo 0)
+dashboard_custom_url=$(uci_get_config "dashboard_custom_url" || echo 0)
 
 [ "$china_ip_route" -ne 0 ] && [ "$china_ip_route" -ne 1 ] && [ "$china_ip_route" -ne 2 ] && china_ip_route=0
 [ "$china_ip6_route" -ne 0 ] && [ "$china_ip6_route" -ne 1 ] && [ "$china_ip6_route" -ne 2 ] && china_ip6_route=0
@@ -312,7 +315,11 @@ config_load "openclash"
 config_foreach yml_auth_get "authentication"
 yml_dns_custom "$enable_custom_dns" "$5" "$append_wan_dns" "${16}"
 
-ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "
+OPENCLASH_CORS_DOMAIN="${36}" \
+OPENCLASH_CORS_PORT="$dashboard_forward_port" \
+OPENCLASH_CORS_SSL="$dashboard_forward_ssl" \
+OPENCLASH_CORS_CUSTOM_URL="$dashboard_custom_url" \
+ruby -ryaml -rYAML -ruri -I "/usr/share/openclash" -E UTF-8 -e "
 
 def safe_load_yaml(file_path)
    return nil unless File.exist?(file_path)
@@ -326,6 +333,41 @@ def merge_list_from_file(dns_hash, key, file_path)
    lines = File.readlines(file_path).map { |l| l.gsub(/#.*$/, '').strip }.reject(&:empty?)
    return if lines.empty?
    (dns_hash[key] ||= []).unshift(*lines).uniq!
+end
+
+def http_origin(raw_url)
+   uri = URI.parse(raw_url.to_s.strip)
+   scheme = uri.scheme.to_s.downcase
+   return nil unless %w[http https].include?(scheme) && uri.hostname && !uri.hostname.empty? && !uri.userinfo
+   return nil unless uri.port.between?(1, 65_535)
+   host = uri.hostname.include?(':') ? '[' + uri.hostname + ']' : uri.hostname
+   default_port = scheme == 'https' ? 443 : 80
+   scheme + '://' + host + (uri.port == default_port ? '' : ':' + uri.port.to_s)
+rescue URI::Error
+   nil
+end
+
+def controller_origin(domain, configured_port, ssl)
+   domain = domain.to_s.strip
+   return nil if domain.empty? || domain == '0'
+   domain_url = domain =~ /\Ahttps?:\/\//i ? domain : 'http://' + domain
+   uri = URI.parse(domain_url)
+   return nil unless uri.hostname && !uri.hostname.empty? && !uri.userinfo
+
+   port_text = configured_port.to_s.strip
+   authority = domain.sub(/\Ahttps?:\/\//i, '').split(/[\/?#]/, 2).first.to_s
+   embedded_port = authority[/\A\[[^\]]+\]:(\d+)\z/, 1] || authority[/\A[^:]+:(\d+)\z/, 1]
+   port_text = embedded_port if (port_text.empty? || port_text == '0') && embedded_port
+
+   scheme = ssl.to_s == '1' ? 'https' : 'http'
+   default_port = scheme == 'https' ? 443 : 80
+   port_text = default_port.to_s if port_text.empty? || port_text == '0'
+   return nil unless (port_text =~ /\A\d+\z/) && port_text.to_i.between?(1, 65_535)
+   host = uri.hostname.include?(':') ? '[' + uri.hostname + ']' : uri.hostname
+   port = port_text.to_i
+   scheme + '://' + host + (port == default_port ? '' : ':' + port.to_s)
+rescue URI::Error
+   nil
 end
 
 
@@ -378,7 +420,7 @@ begin
    fake_ip_filter_mode = '${33}'
    routing_mark_setting = '${34}'
    quic_gso = '${35}' == '1'
-   cors_origin = '${36}'
+   cors_origin = http_origin(ENV['OPENCLASH_CORS_CUSTOM_URL']) || controller_origin(ENV['OPENCLASH_CORS_DOMAIN'], ENV['OPENCLASH_CORS_PORT'], ENV['OPENCLASH_CORS_SSL'])
    geo_custom_url = '${37}'
    geoip_custom_url = '${38}'
    geosite_custom_url = '${39}'
@@ -455,7 +497,7 @@ begin
          Value['find-process-mode'] = find_process_mode if find_process_mode != '0'
 
          (Value['experimental'] ||= {})['quic-go-disable-gso'] = true if quic_gso
-         if cors_origin != '0'
+         if cors_origin
             (Value['external-controller-cors'] ||= {})['allow-origins'] = [cors_origin]
             Value['external-controller-cors']['allow-private-network'] = true
          end

--- a/luci-app-openclash/root/www/luci-static/resources/openclash/js/common.js
+++ b/luci-app-openclash/root/www/luci-static/resources/openclash/js/common.js
@@ -317,36 +317,111 @@ function ocDebounce(fn, delay) {
 	};
 }
 
-function ocGetDashboardBaseURL(status) {
-	var host, port, proto;
-	if (status.daip && window.location.hostname === status.daip) {
-		host = window.location.hostname;
-		port = status.cn_port;
-		proto = 'http://';
-	} else if (status.daip && status.db_foward_domain && status.db_foward_port) {
-		host = status.db_foward_domain;
-		port = status.db_foward_port;
-		proto = (status.db_forward_ssl == 0 ? 'http://' : 'https://');
-	} else {
-		host = window.location.hostname;
-		port = status.cn_port;
-		proto = 'http://';
+function ocGetCustomDashboardURL(status) {
+	var raw = status && status.dashboard_custom_url ? String(status.dashboard_custom_url).trim() : '';
+	if (!raw) return '';
+	if (/[\x00-\x20\\<>"{}|^`\x7f-\uffff]/.test(raw) || /%(?![0-9a-f]{2})/i.test(raw)) return '';
+	try {
+		var parsed = new URL(raw);
+		if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') || !parsed.hostname || parsed.username || parsed.password) return '';
+		return raw;
+	} catch (e) {
+		return '';
 	}
-	return { host: host, port: port, proto: proto, secret: status.dase || '' };
+}
+
+function ocGetDashboardBaseURL(status) {
+	var publicHost = status.db_foward_domain ? String(status.db_foward_domain).trim() : '';
+	var embeddedPortMatch = publicHost.match(/\]:(\d+)(?:[\/?#]|$)/) || publicHost.match(/^(?:https?:\/\/)?[^:\/?#]+:(\d+)(?:[\/?#]|$)/i);
+	var embeddedPort = embeddedPortMatch ? embeddedPortMatch[1] : '';
+	var publicPort = status.db_foward_port ? String(status.db_foward_port).trim() : '';
+	var validPublicPort = /^\d+$/.test(publicPort) && Number(publicPort) > 0 && Number(publicPort) <= 65535;
+	var usePublic = !!(status.daip && window.location.hostname !== status.daip && publicHost);
+	var rawHost = usePublic ? publicHost : window.location.hostname;
+	var proto = usePublic && status.db_forward_ssl != 0 ? 'https:' : 'http:';
+	var configuredPort = usePublic ? publicPort : status.cn_port;
+	var parsed;
+
+	try {
+		parsed = new URL(/^https?:\/\//i.test(rawHost) ? rawHost : 'http://' + rawHost);
+		if (!parsed.hostname || parsed.username || parsed.password) throw new Error('invalid dashboard host');
+		var legacyPort = embeddedPort || parsed.port;
+		parsed.protocol = proto;
+		parsed.pathname = '/';
+		parsed.search = '';
+		parsed.hash = '';
+		if (usePublic && validPublicPort) {
+			parsed.port = String(configuredPort);
+		} else if (usePublic && legacyPort) {
+			parsed.port = legacyPort;
+		} else if (usePublic) {
+			parsed.port = proto === 'https:' ? '443' : '80';
+		} else if (!usePublic && configuredPort && /^\d+$/.test(String(configuredPort)) && Number(configuredPort) > 0 && Number(configuredPort) <= 65535) {
+			parsed.port = String(configuredPort);
+		}
+	} catch (e) {
+		parsed = new URL('http://' + window.location.hostname);
+		if (status.cn_port) parsed.port = status.cn_port;
+		usePublic = false;
+	}
+
+	var effectivePort = parsed.port || (parsed.protocol === 'https:' ? '443' : '80');
+	return { host: parsed.hostname, port: effectivePort, proto: parsed.protocol + '//', origin: parsed.origin, secret: status.dase || '', isPublic: usePublic };
+}
+
+function ocGetDashboardWebSocketOrigin(status) {
+	return ocGetDashboardBaseURL(status).origin.replace(/^http/, 'ws');
+}
+
+function ocGetDashboardLoginParams(base, clashCompatible) {
+	var params = new URLSearchParams();
+	params.set(clashCompatible ? 'host' : 'hostname', base.host);
+	params.set('port', base.port);
+	if (base.secret) params.set('secret', base.secret);
+	return params;
+}
+
+function ocBuildExternalDashboardURL(status) {
+	var customURL = ocGetCustomDashboardURL(status);
+	if (!customURL) return '';
+
+	var base = ocGetDashboardBaseURL(status);
+	var clashCompatible = String(status.dashboard_custom_clash_compatible) === '1';
+	var parsed = new URL(customURL);
+	var params = ocGetDashboardLoginParams(base, clashCompatible);
+
+	if (clashCompatible) {
+		var compatHash = parsed.hash.substring(1);
+		var compatSeparator = compatHash.indexOf('?');
+		var compatParams = new URLSearchParams(compatSeparator === -1 ? '' : compatHash.substring(compatSeparator + 1));
+		compatParams.delete('hostname');
+		params.forEach(function(value, key) { compatParams.set(key, value); });
+		parsed.hash = '#/?' + compatParams.toString();
+	} else if (!parsed.hash) {
+		parsed.searchParams.delete('host');
+		params.forEach(function(value, key) { parsed.searchParams.set(key, value); });
+	} else {
+		var hash = parsed.hash.substring(1);
+		var separator = hash.indexOf('?');
+		var route = separator === -1 ? hash : hash.substring(0, separator);
+		var hashParams = new URLSearchParams(separator === -1 ? '' : hash.substring(separator + 1));
+		hashParams.delete('host');
+		params.forEach(function(value, key) { hashParams.set(key, value); });
+		parsed.hash = '#' + route + '?' + hashParams.toString();
+	}
+	return parsed.toString();
 }
 
 function ocBuildDashboardURL(status, uiPath, needsSetup) {
 	var base = ocGetDashboardBaseURL(status);
-	var url = base.proto + base.host + ':' + base.port + '/ui/' + uiPath;
+	var url = base.origin + '/ui/' + uiPath;
+	var params = ocGetDashboardLoginParams(base, uiPath === 'dashboard').toString();
 	if (needsSetup) {
-		url += '/#/setup?hostname=' + base.host + '&port=' + base.port;
-		if (base.secret) url += '&secret=' + base.secret;
+		url += '/#/setup?' + params;
 	} else if (uiPath === 'yacd') {
-		url += '/?hostname=' + base.host + '&port=' + base.port;
-		if (base.secret) url += '&secret=' + base.secret;
+		url += '/?' + params;
 	} else if (uiPath === 'dashboard') {
-		url += '/#/?host=' + base.host + '&port=' + base.port;
-		if (base.secret) url += '&secret=' + base.secret;
+		url += '/#/?' + params;
 	}
 	return url;
 }


### PR DESCRIPTION
## 变更说明

- 支持为 Dashboard 公网域名自动补全 HTTP/HTTPS 默认端口，并统一 Dashboard 与 WebSocket 地址生成逻辑
- 根据公网 Controller 或自定义外部面板 URL 生成 `external-controller-cors` Origin
- 新增自定义外部面板 URL，以及独立的主页面“外部面板”按钮，不影响 Yacd、Dashboard、MetaCubeXD 和 Zashboard 本地按钮
- 自动追加 `hostname`、`port`、`secret` 参数，并提供 Clash Dashboard `#/?host=...` 兼容模式
- 保留外部 URL 原有路径、Hash 路由和无关参数

## 验证

- `node --check` 公共 JavaScript
- LuCI `status.htm`、`log.htm` 内联脚本解析
- `bash -n` 检查 `yml_change.sh`
- HTTP/HTTPS 默认端口、显式端口、WebSocket、本地四面板、外部普通/Hash/兼容模式 URL 矩阵
- `git diff --check`