### PR TITLE
fix: 补齐 ruby-uri 依赖并在启动前检查

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 * ip-full
 * ruby
 * ruby-yaml
+* ruby-uri
 * unzip
 * iptables(iptables)
 * kmod-ipt-nat(iptables)

--- a/luci-app-openclash/Makefile
+++ b/luci-app-openclash/Makefile
@@ -43,7 +43,7 @@ define Package/$(PKG_NAME)
 	TITLE:=LuCI support for clash
 	PKGARCH:=all
 	DEPENDS:=+dnsmasq-full +bash +curl +ca-bundle +ip-full \
-	+ruby +ruby-yaml +kmod-tun +unzip
+	+ruby +ruby-yaml +ruby-uri +kmod-tun +unzip
 	MAINTAINER:=vernesong
 endef
 

--- a/luci-app-openclash/root/etc/init.d/openclash
+++ b/luci-app-openclash/root/etc/init.d/openclash
@@ -429,14 +429,14 @@ config_check()
 #rm -rf "/etc/openclash/*.y*" 2>/dev/null
 cp "$RAW_CONFIG_FILE" "$TMP_CONFIG_FILE"
 
-ruby -ryaml -rYAML -I "/usr/share/openclash" -E UTF-8 -e "
+ruby -ryaml -rYAML -ruri -I "/usr/share/openclash" -E UTF-8 -e "
 begin
    YAML.load_file('$RAW_CONFIG_FILE');
 rescue Exception => e
    YAML.LOG_ERROR('Unable To Parse Config File,【' + e.message + '】');
    system 'rm -rf ${TMP_CONFIG_FILE}';
 end
-" 2>/dev/null >> $LOG_FILE
+" >> "$LOG_FILE" 2>&1
 if [ $? -ne 0 ]; then
    LOG_ERROR "Ruby Works Abnormally, Please Check The Ruby Library Depends!"
    start_fail

--- a/tests/test_ruby_uri_startup.sh
+++ b/tests/test_ruby_uri_startup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Run config_check and start_fail without sourcing the router init script.
+# TEST_SHELL may point to another shell executable, such as BusyBox ash.
+set -eu
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+INIT="$ROOT/luci-app-openclash/root/etc/init.d/openclash"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    [ ! -f "${LOG_FILE:-}" ] || cat "$LOG_FILE" >&2
+    [ ! -f "${TRACE_FILE:-}" ] || cat "$TRACE_FILE" >&2
+    exit 1
+}
+
+for name in config_check start_fail; do
+    awk -v name="$name" -v helper="$ROOT/luci-app-openclash/root/usr/share/openclash/YAML.rb" '
+        $0 == name "()" { copying = 1 }
+        # An absolute helper path avoids shadowing stdlib yaml.rb on macOS.
+        copying { sub(/-rYAML/, "-r\"" helper "\""); print }
+        copying && /^}$/ { exit }
+    ' "$INIT" >> "$WORK/functions.sh"
+    grep -q "^$name()" "$WORK/functions.sh" || fail "cannot extract $name"
+done
+
+cat > "$WORK/run.sh" <<'SH'
+LOG_ERROR() { printf '%s\n' "$*" >> "$LOG_FILE"; }
+uci() { printf 'uci %s\n' "$*" >> "$TRACE_FILE"; }
+stop() { printf 'stop\n' >> "$TRACE_FILE"; }
+. "$FUNCTIONS_FILE"
+config_check
+printf 'continued\n' >> "$TRACE_FILE"
+SH
+
+mkdir "$WORK/missing"
+printf '%s\n' 'raise LoadError, "cannot load such file -- uri"' > "$WORK/missing/uri.rb"
+printf 'mixed-port: 7890\n' > "$WORK/valid.yaml"
+printf 'dns: [\n' > "$WORK/invalid.yaml"
+
+run_case() {
+    local name=$1 input=$2 extra_lib=${3:-}
+    export RAW_CONFIG_FILE="$WORK/$input.yaml"
+    export TMP_CONFIG_FILE="$WORK/$name.copy.yaml"
+    export LOG_FILE="$WORK/$name.log" TRACE_FILE="$WORK/$name.trace"
+    export FUNCTIONS_FILE="$WORK/functions.sh"
+    : > "$LOG_FILE"
+    : > "$TRACE_FILE"
+    # Keep host RubyGems from loading uri before the startup check.
+    RUBYOPT=--disable-gems RUBYLIB="$extra_lib" \
+        "${TEST_SHELL:-/bin/sh}" "$WORK/run.sh" || fail "$name harness failed"
+}
+
+assert_stopped() {
+    # start_fail exits with status 0, so inspect its effects and continuation.
+    grep -Fxq 'uci -q set openclash.config.enable=0' "$TRACE_FILE" || fail 'start_fail did not disable OpenClash'
+    grep -Fxq 'uci -q commit openclash' "$TRACE_FILE" || fail 'start_fail did not commit'
+    grep -Fxq 'stop' "$TRACE_FILE" || fail 'stop was not called'
+    ! grep -Fxq 'continued' "$TRACE_FILE" || fail 'startup continued after failure'
+}
+
+run_case valid valid
+grep -Fxq 'continued' "$TRACE_FILE" || fail 'valid config was rejected'
+[ "$(cat "$TRACE_FILE")" = continued ] || fail 'valid config stopped startup'
+cmp -s "$RAW_CONFIG_FILE" "$TMP_CONFIG_FILE" || fail 'valid config copy changed'
+[ ! -s "$LOG_FILE" ] || fail 'valid config produced errors'
+printf 'PASS: valid config\n'
+
+run_case invalid invalid
+assert_stopped
+grep -Fq 'Unable To Parse Config File' "$LOG_FILE" || fail 'YAML parser error is missing'
+grep -Fq 'Config File Format Validation Failed' "$LOG_FILE" || fail 'invalid YAML was not rejected'
+[ ! -e "$TMP_CONFIG_FILE" ] || fail 'invalid config copy was kept'
+printf 'PASS: invalid YAML\n'
+
+run_case missing_uri valid "$WORK/missing"
+! grep -Fxq 'continued' "$TRACE_FILE" || fail 'missing uri allowed startup to continue'
+assert_stopped
+grep -Fq 'cannot load such file -- uri' "$LOG_FILE" || fail 'LoadError detail is missing'
+grep -Fq 'Ruby Works Abnormally' "$LOG_FILE" || fail 'dependency error is missing'
+printf 'PASS: missing uri stops startup and logs the cause\n'
+
+awk '
+    /^[[:space:]]*DEPENDS[[:space:]]*[:+?]?=/ { in_depends = 1 }
+    in_depends && /(^|[[:space:]])\+ruby-uri([[:space:]\\]|$)/ { found = 1 }
+    in_depends && !/\\$/ { in_depends = 0 }
+    END { exit !found }
+' "$ROOT/luci-app-openclash/Makefile" || fail 'package dependency ruby-uri is missing'
+printf 'PASS: ruby-uri package dependency\n'


### PR DESCRIPTION
0.47.162 在 `yml_change.sh` 中新增了 `-ruri`，但没有声明 `ruby-uri` 依赖。缺少这个库时，配置覆写会直接退出，端口和 TUN 设置没有生效，最后表现为等待约 20 分钟后报配置初始化超时。#5315 中的启动失败可以由此复现。

这次补上包依赖和 README 中的依赖说明，并让现有 `config_check` 同时加载 `uri`、保留标准错误。缺库时会直接走已有的启动失败处理，日志也能看到具体的 `LoadError`。

验证：

- 新增 `tests/test_ruby_uri_startup.sh`，覆盖有效 YAML、非法 YAML、缺少 URI 时停止启动并记录原因，以及包依赖声明。缺库用例在修复前失败，修复后全部通过。
- 测试已分别在 macOS / Ruby 2.6 和 iStoreOS / Ruby 3.0 / BusyBox ash 下通过；路由器测试在临时目录运行。
- 运行脚本及测试的 Bash 语法检查、init 的 BusyBox ash 语法检查、`po2lmo` 构建和 `git diff --check` 均通过。
- 未运行完整 OpenWrt SDK 打包。

Refs #5315，处理其中缺少 `ruby-uri` 导致启动超时的问题。
